### PR TITLE
Fixes and enhancements for clusterbuster to work with kubectl

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -147,7 +147,7 @@ function warn() {
 
 if [[ -z "$OC" ]] ; then
     fatal "Can't find kubectl or oc"
-elif [[ $OC = 'kubectl'* ]] ; then
+elif [[ $OC =~ 'kubectl' ]] ; then
     KUBECTL_VALIDATE=--validate=false
 fi
 

--- a/clusterbuster
+++ b/clusterbuster
@@ -1016,10 +1016,6 @@ fi
 
 shift $((OPTIND - 1))
 
-if [[ -z $OC && $doit -gt 0 ]] ; then
-    fatal "Cannot find oc or kubectl command, exiting!"
-fi
-
 if (( msgSize <= 0 )) ; then
     fatal "Message size must be positive, exiting!"
 fi

--- a/clusterbuster
+++ b/clusterbuster
@@ -155,16 +155,14 @@ declare __me__
 __me__=$(realpath -e "$0")
 
 if [[ -z "$__me__" ]] ; then
-    echo "Can't find my path!" 1>&2
-    exit 1
+    fatal "Can't find my path!"
 fi
 
 declare __mydir__=${__me__%/*}
 declare __libdir__=${__mydir__}/lib/clusterbuster
 
 if [[ ! -d "$__libdir__" ]] ; then
-    echo "Can't find my library dir!" 1>&2
-    exit 1
+    fatal "Can't find my library dir!"
 fi
 
 function _helpmsg() {

--- a/clusterbuster
+++ b/clusterbuster
@@ -1472,7 +1472,7 @@ function createContainersClusterBusterYAML() {
 	cat <<EOF
 - name: ${namespace}-$i-$j
   imagePullPolicy: $imagePullPolicy
-  image: "busybox"
+  image: "$containerImage"
 $(indent 2 createContainerResources)
   command:
   - /bin/sh


### PR DESCRIPTION
After these changes, clusterbuster is working with kubectl:

```
[root@server OpenShift4-tools]# ./clusterbuster -B panda -c 3 -d 2 -N 4 -z 99 -r 10 -P classic --container_image=quay.io/quay/busybox --image_pull_policy=IfNotPresent
2021-08-04T23:05:08.502898 namespace/panda-0 created
2021-08-04T23:05:09.102435 namespace/panda-1 configured
2021-08-04T23:05:09.661726 namespace/panda-2 configured
2021-08-04T23:05:10.183601 namespace/panda-3 configured
2021-08-04T23:05:10.889919 deployment.apps/panda-0-0 created
2021-08-04T23:05:12.135847 deployment.apps/panda-0-1 created
2021-08-04T23:05:13.331540 deployment.apps/panda-1-0 created
2021-08-04T23:05:14.803379 deployment.apps/panda-1-1 created
2021-08-04T23:05:15.846889 deployment.apps/panda-2-0 created
2021-08-04T23:05:16.952008 deployment.apps/panda-2-1 created
2021-08-04T23:05:18.325334 deployment.apps/panda-3-0 created
2021-08-04T23:05:19.382205 deployment.apps/panda-3-1 created
Created 1 namespace
Created 1 object total
```