### PR TITLE
Use deployments rather than pods to spawn cpusoaker processes

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -1138,7 +1138,7 @@ function monitor_pods() {
 		    oc logs -n "$namespace" "$name" |tail -20 1>&2
 		    killthemall
 		    ;;
-		pending)
+		pending|containercreating)
 		    other_pod_count=$((other_pod_count+1))
 		    pending_pods+=("$namespace/$name")
 		    ;;
@@ -2502,7 +2502,7 @@ function _do_cleanup() {
     if ! _do_cleanup_1 "$@" ; then
 	if [[ -n "$force_cleanup_timeout" ]] ; then
 	    warn "*** Cleanup failed, doing a force delete!"
-	    __OC delete pod,deployment,configmap,secret,service -A  -l "$basename" --force --grace-period=0 1>&2
+	    __OC delete deployment,replicaset,pod,configmap,secret,service -A  -l "$basename" --force --grace-period=0 1>&2
 	    if ((use_namespaces)) ; then
 		__OC delete namespace -l "$basename" --force --grace-period=0 1>&2
 	    fi
@@ -2841,10 +2841,17 @@ if [[ -n "$metrics_file" && ! -r "$metrics_file" ]] ; then
     fatal "Cannot read metrics file $metrics_file"
 fi
 
-if [[ $deployment_type != pod && $deployment_type != deployment ]] ; then
-    echo "--deployment_type must be either pod or deployment"
-    help
-fi
+case "${deployment_type,,}" in
+    # If we're using deployments or replicasets, we do not want
+    # to exit when workers complete, or the controller will
+    # immediately try to re-create them.
+    replicaset) deployment_type=ReplicaSet; exit_at_end=0 ;;
+    deployment) deployment_type=Deployment; exit_at_end=0 ;;
+    pod) deployment_type=pod		   		  ;;
+    *)
+	echo "--deployment_type must be pod, deployment, or replicaset"
+	help
+esac
 
 if [[ -z $OC && $doit -gt 0 ]] ; then
     fatal "Cannot find oc or kubectl command, exiting!"

--- a/clusterbuster
+++ b/clusterbuster
@@ -217,8 +217,8 @@ Usage: $0 [options] [name]
 
     Options:
        -B basename     Base name of pods.  Default is
-       	  	       \$CLUSTERBUSTER_DEFAULT_BASENAME if defined or
-		       otherwise 'clusterbuster'.
+                       \$CLUSTERBUSTER_DEFAULT_BASENAME if defined or
+                       otherwise 'clusterbuster'.
                        All objects are labeled with this name.
        -E              Don't exit after all operations are complete.
        -e              Exit after all operations are complete (default).
@@ -255,7 +255,7 @@ EOF
        --basename=name  Specify the base name for any namespaces (-B)
        --namespaces=N   Number of namespaces
        --jobfile=jobfile
-			Process job file (-f)
+                        Process job file (-f)
        --sync           Synchronize start of workload instances (default yes)
        --precleanup     Clean up any prior objects
        --cleanup        Clean up generated objects
@@ -422,7 +422,7 @@ $(print_workloads_supporting_reporting '                        - ')
        --first_deployment=N
                         Index number of first pod to be created
        --pod-prefix=prefix
-			Prefix all created pods with this prefix.
+                        Prefix all created pods with this prefix.
        --sleep=N        Number of seconds between object creations
                         Below options default to sleeptime
        --sleep_between_secrets=N
@@ -430,19 +430,19 @@ $(print_workloads_supporting_reporting '                        - ')
        --sleep_between_deployments=N
 
        --objs_per_call=N
-			Number of objects per CLI call.  Only objects
-       			within a namespace can be created this way;
-			to improve creation performance with multiple
-			namespaces, use --parallel.
+                        Number of objects per CLI call.  Only objects
+                        within a namespace can be created this way;
+                        to improve creation performance with multiple
+                        namespaces, use --parallel.
                         Below options all default to objs_per_call
        --objs_per_call_secrets=N
        --objs_per_call_namespaces=N
        --objs_per_call_deployments=N
 
        --parallel=N     Number of operations in parallel.  Only
-       			operations across namespaces can be
-			parallelized; to improve performance
-			within one namespace, use --objs_per_call.
+                        operations across namespaces can be
+                        parallelized; to improve performance
+                        within one namespace, use --objs_per_call.
                         Below options all default to parallel
        --parallel_secrets=N
        --parallel_namespaces=N
@@ -459,7 +459,7 @@ $(print_workloads_supporting_reporting '                        - ')
 Workload-specific options:
 $(_help_options_workloads)
 
-    Advanced options (generally not required):
+Advanced options (generally not required):
        --baseoffset=N   Add specified offset to base time
                         for calculation of start time offset
                         to correct for clock skew.  May be float.

--- a/clusterbuster
+++ b/clusterbuster
@@ -867,13 +867,14 @@ function ___OC() {
 # The big red button if something goes wrong.
 
 function childrenof() {
+    IFS=' '
     function is_descendent() {
-	local pid=$1
+	local -i child=$1
 	local ancestor=$2
-	if ((pid == ancestor)) ; then
+	if ((child == ancestor)) ; then
 	    true
 	else
-	    parent=${ps_parents[$pid]:-1}
+	    parent=${ps_parents[$child]:-1}
 	    case "$parent" in
 		1)           false ;;
 		"$ancestor") true  ;;
@@ -893,10 +894,11 @@ function childrenof() {
     local target=$1
     local -A ps_parents=()
     local -A ps_commands=()
-    local -i ppid
-    local -i pid
+    local ppid
+    local pid
+    local command
     local ignore
-    while read -r pid ppid command ; do
+    while read -r pid ppid command ignore; do
 	ps_parents["$pid"]=$ppid
 	ps_commands["$pid"]=$command
     done <<< "$(ps -axo pid,ppid,command | tail -n +2)"
@@ -1695,8 +1697,8 @@ labels:
 EOF
     if [[ -n "$workload" ]] ; then
 	cat <<EOF
-  name: "${namespace}-${workload}-${instance}"
-  app: "${namespace}-${workload}-${instance}"
+  name: "${namespace}${workload:+-$workload}${instance:+-$instance}"
+  app: "${namespace}${workload:+-$workload}${instance:+-$instance}"
   ${basename}-${workload}: "true"
 ${logger:+  ${basename}-logger: $true}
 EOF
@@ -1981,9 +1983,9 @@ EOF
 # Object YAML creation
 ################################################################
 
-function really_create_objects() {
+function _really_create_objects() {
     if [[ $doit -ne 0 && -n $accumulateddata ]] ; then
-	(__OC --validate=false apply -f - <<< "$accumulateddata" | timestamp 1>&2) || {
+	__OC --validate=false apply -f - <<< "$accumulateddata" || {
 	    echo "Create objects failed:" 1>&2
 	    echo "$accumulateddata" 1>&2
 	    killthemall "Failed to create objects"
@@ -1991,6 +1993,12 @@ function really_create_objects() {
 	accumulateddata=
 	objs_item_count=0
     fi
+}
+
+function really_create_objects() {
+    _really_create_objects "$@" | timestamp 1>&2
+    accumulateddata=
+    objs_item_count=0
 }
 
 function create_object() {
@@ -2014,7 +2022,7 @@ function create_object() {
     local -i data_found=0
     while IFS='' read -r 'line' ; do
 	line=${line%% }
-	if [[ -n $line ]] ; then
+	if [[ $line =~ [^[:space:]] ]] ; then
 	    data_found=1
 	    [[ -n $data ]] || data="---$nl"
 	    data+="$line$nl"
@@ -2045,7 +2053,7 @@ function echo_if_desired() {
     fi
 }
 
-function create_object_from_file() {
+function _create_object_from_file() {
     function _ns() {
 	((use_namespaces)) && echo -n "-n $namespace"
     }
@@ -2059,9 +2067,9 @@ function create_object_from_file() {
 	[[ -r "$file" ]] || fatal "Can't read file $file!"
     done
     # shellcheck disable=SC2046
-    (_OC create "$objtype" $(_ns) "$objname" "${@/#/--from-file=}" | echo_if_desired 1>&2) || killthemall "Unable to create object $objtype/$namespace:$objname"
+    _OC create "$objtype" $(_ns) "$objname" "${@/#/--from-file=}" || killthemall "Unable to create object $objtype/$namespace:$objname"
     # shellcheck disable=SC2046
-    (_OC label "$objtype" $(_ns) "$objname" "${basename}base=true" 'clusterbusterbase=true' "${basename}-uuid=${uuid}" "${basename}-id=$uuid" "${basename}=true" | echo_if_desired 1>&2) || killthemall "Unable to label $objtype/$namespace:$objname"
+    _OC label "$objtype" $(_ns) "$objname" "${basename}base=true" 'clusterbusterbase=true' "${basename}-uuid=${uuid}" "${basename}-id=$uuid" "${basename}=true" || killthemall "Unable to label $objtype/$namespace:$objname"
     if (( doit )) ; then
 	if [[ -n "$artifactdir" ]] ; then
 	    mkdir -p "$artifactdir/$objtype"
@@ -2080,6 +2088,10 @@ function create_object_from_file() {
 	fi
 	(( !sleeptime )) || sleep "$sleeptime"
     fi
+}
+
+function create_object_from_file() {
+    _create_object_from_file "$@" |echo_if_desired |timestamp 1>&2
 }
 
 function create_namespace() {
@@ -2457,12 +2469,12 @@ function create_all_objects() {
 	if [[ $line = *'__KUBEFAIL__ '* ]] ; then
 	    echo "${line#__KUBEFAIL__ }" 1>&2
 	    return 1
-	elif [[ $line =~ ^[[:digit:]]{4}(-[[:digit:]]{2}){2}T([[:digit:]]{2}:){2}[[:digit:]]{2}\.[[:digit:]]{6}\ +([-a-z0-9]+)/([-a-z0-9]+)\ +created$ ]] ; then
+	elif [[ $line =~ ^[[:digit:]]{4}(-[[:digit:]]{2}){2}T([[:digit:]]{2}:){2}[[:digit:]]{2}\.[[:digit:]]{6}\ +(([-a-z0-9]+)(\.[-a-z0-9]*)?)/([-a-z0-9]+)\ +created$ ]] ; then
 	    if (( report_object_creation )) ; then
 		echo "$line" 1>&2
 	    fi
 	    total_objects_created=$((total_objects_created+1))
-	    found_objtype=${BASH_REMATCH[3]}
+	    found_objtype=${BASH_REMATCH[4]}
 	    if [[ -z ${objects_created[$found_objtype]:-} ]] ; then
 		objects_created[$found_objtype]=1
 	    else
@@ -2845,8 +2857,8 @@ case "${deployment_type,,}" in
     # If we're using deployments or replicasets, we do not want
     # to exit when workers complete, or the controller will
     # immediately try to re-create them.
-    replicaset) deployment_type=ReplicaSet; exit_at_end=0 ;;
-    deployment) deployment_type=Deployment; exit_at_end=0 ;;
+    replicaset|rs)         deployment_type=ReplicaSet; exit_at_end=0 ;;
+    deployment|dep|deploy) deployment_type=Deployment; exit_at_end=0 ;;
     pod) deployment_type=pod		   		  ;;
     *)
 	echo "--deployment_type must be pod, deployment, or replicaset"

--- a/examples/clusterbuster/classic
+++ b/examples/clusterbuster/classic
@@ -5,6 +5,6 @@ cleanup
 workload=classic
 precleanup=1
 no-report-object-creation
-deps-per-namespace=8
+replicas=8
 namespaces=1
 exit_at_end

--- a/examples/clusterbuster/files
+++ b/examples/clusterbuster/files
@@ -9,7 +9,7 @@ file_block_size=1024
 file_size=1024
 precleanup=1
 no-report-object-creation
-deps-per-namespace=8
+replicas=8
 namespaces=1
 exit_at_end
 

--- a/examples/clusterbuster/fio
+++ b/examples/clusterbuster/fio
@@ -4,9 +4,8 @@
 cleanup
 workloadruntime=10
 workload=fio
-replicas=1
+replicas=4
 anti_affinity
 exit_at_end
 precleanup
 no-report-object-creation
-depspernamespace=4

--- a/examples/clusterbuster/log
+++ b/examples/clusterbuster/log
@@ -1,0 +1,10 @@
+# Run as
+# clusterbuster -f clusterbuster-classic-jobfile
+
+precleanup
+workload=log
+precleanup=1
+no-report-object-creation
+replicas=8
+namespaces=1
+exit_at_end

--- a/examples/clusterbuster/memory
+++ b/examples/clusterbuster/memory
@@ -1,0 +1,12 @@
+# Run as
+# clusterbuster -f memory
+
+cleanup
+workload=memory
+workloadruntime=10
+precleanup=1
+no-report-object-creation
+replicas=8
+processes=3
+namespaces=1
+memorysize=1Gi

--- a/examples/clusterbuster/pausepod
+++ b/examples/clusterbuster/pausepod
@@ -5,6 +5,6 @@ precleanup
 workload=pausepod
 precleanup=1
 no-report-object-creation
-deps-per-namespace=8
+replicas=8
 namespaces=1
 exit_at_end

--- a/lib/clusterbuster/CI/profiles/func_ci.profile
+++ b/lib/clusterbuster/CI/profiles/func_ci.profile
@@ -30,3 +30,4 @@ virtiofsd-direct=1
 use-python-venv=1
 cleanup=1
 restart=0
+deployment-type=replicaset

--- a/lib/clusterbuster/CI/profiles/func_ci.profile
+++ b/lib/clusterbuster/CI/profiles/func_ci.profile
@@ -22,8 +22,8 @@ uperf-ninst=1
 uperf-timeout=300
 
 cpusoaker-timeout=300
-cpusoaker-deps-per-namespace=10
-cpusoaker-max-namespaces=3
+cpusoaker-replica-increment=10
+cpusoaker-max-replicas=30
 
 artifactdir=
 virtiofsd-direct=1

--- a/lib/clusterbuster/CI/profiles/perf_ci.profile
+++ b/lib/clusterbuster/CI/profiles/perf_ci.profile
@@ -31,3 +31,4 @@ virtiofsd-direct=1
 use-python-venv=1
 cleanup=1
 restart=0
+deployment-type=replicaset

--- a/lib/clusterbuster/CI/profiles/perf_ci.profile
+++ b/lib/clusterbuster/CI/profiles/perf_ci.profile
@@ -24,7 +24,7 @@ uperf-ninst=1,4
 uperf-timeout=300
 
 cpusoaker-timeout=600
-cpusoaker-deps-per-namespace=20
+cpusoaker-replica-increment=20
 
 artifactdir=
 virtiofsd-direct=1

--- a/lib/clusterbuster/CI/profiles/release.profile
+++ b/lib/clusterbuster/CI/profiles/release.profile
@@ -34,3 +34,4 @@ virtiofsd-direct=1
 restart=0
 use-python-venv=1
 cleanup=1
+deployment-type=replicaset

--- a/lib/clusterbuster/CI/profiles/test_ci.profile
+++ b/lib/clusterbuster/CI/profiles/test_ci.profile
@@ -31,3 +31,4 @@ virtiofsd-direct=1
 use-python-venv=1
 cleanup=1
 restart=0
+deployment-type=replicaset

--- a/lib/clusterbuster/CI/profiles/test_ci.profile
+++ b/lib/clusterbuster/CI/profiles/test_ci.profile
@@ -23,8 +23,8 @@ uperf-ninst=1
 uperf-timeout=300
 
 cpusoaker-timeout=300
-cpusoaker-deps-per-namespace=10
-cpusoaker-max-namespaces=1
+cpusoaker-replica-increment=10
+cpusoaker-max-replicas=10
 
 artifactdir=
 virtiofsd-direct=1

--- a/lib/clusterbuster/CI/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.workload
@@ -22,7 +22,7 @@ declare -gi ___cpusoaker_job_timeout=0
 
 register_workload cpusoaker dispatch_generic cpu cpusoak scaling
 
-function test_cpusoaker() {
+function cpusoaker_test() {
     local default_job_runtime=$1
     if ((___cpusoaker_replica_increment < 1)) ; then
 	echo "Replica increment must be at least 1" 1>&2
@@ -70,7 +70,7 @@ function test_cpusoaker() {
     done
 }
 
-function process_option_cpusoaker() {
+function cpusoaker_process_option() {
     local opt=$1
     read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
     case "$noptname1" in
@@ -85,7 +85,7 @@ function process_option_cpusoaker() {
 }
 
 
-function help_options_cpusoaker() {
+function cpusoaker_help_options() {
     cat <<'EOF'
     CPUsoaker options:
         --cpusoaker-starting-replicas=n
@@ -110,7 +110,7 @@ function help_options_cpusoaker() {
 EOF
 }
 
-function document_cpusoaker() {
+function cpusoaker_document() {
 cat <<'EOF'
 * cpusoaker: a simple CPU soaker running a continuous tight loop.
 EOF

--- a/lib/clusterbuster/CI/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.workload
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-declare -gi ___cpusoaker_starting_namespaces=1
-declare -gi ___cpusoaker_deps_per_namespace=5
-declare -gi ___cpusoaker_max_namespaces=-1
+declare -gi ___cpusoaker_starting_replicas=0
+declare -gi ___cpusoaker_replica_increment=5
+declare -gi ___cpusoaker_max_replicas=-1
 declare -gi ___cpusoaker_job_runtime=0
 declare -gi ___cpusoaker_job_timeout=0
 
@@ -24,11 +24,18 @@ register_workload cpusoaker dispatch_generic cpu cpusoak scaling
 
 function test_cpusoaker() {
     local default_job_runtime=$1
+    if ((___cpusoaker_replica_increment < 1)) ; then
+	echo "Replica increment must be at least 1" 1>&2
+	return
+    fi
     if ((___cpusoaker_job_runtime <= 0)) ; then
 	___cpusoaker_job_runtime=$default_job_runtime
     fi
     ___cpusoaker_job_timeout=$(compute_timeout "$___cpusoaker_job_timeout")
-    namespaces=$___cpusoaker_starting_namespaces
+    if ((___cpusoaker_starting_replicas <= 0)) ; then
+	___cpusoaker_starting_replicas=$___cpusoaker_replica_increment
+    fi
+    replicas=$___cpusoaker_starting_replicas
     local -A runtimes_to_test=()
     local runtime
     for runtime in "${runtimeclasses[@]}" ; do
@@ -36,16 +43,15 @@ function test_cpusoaker() {
 	runtimes+=("$runtime")
 	runtimes_to_test[$runtime]=1
     done
-    while ((___cpusoaker_max_namespaces == -1 || namespaces <= ___cpusoaker_max_namespaces)); do
+    while ((___cpusoaker_max_replicas == -1 || replicas <= ___cpusoaker_max_replicas)); do
 	for runtime in "${runtimes[@]}" ; do
 	    if [[ -n "${runtimes_to_test[$runtime]:-}" ]] ; then
 		local xruntime=$runtime
 		if [[ $xruntime = runc ]] ; then xruntime=''; fi
-		job_name="$((namespaces*___cpusoaker_deps_per_namespace))"
+		job_name="$replicas"
 		if run_clusterbuster_1 -r "$xruntime" -y  -j "$job_name" -w cpusoaker \
 				       -t "$___cpusoaker_job_timeout" -R "$___cpusoaker_job_runtime" -- \
-				       --deployments="$___cpusoaker_deps_per_namespace" \
-				       --namespaces="$namespaces" --objs_per_call=6 --parallel=100 ; then
+				       --replicas="$replicas" ; then
 		    :
 		else
 		    unset runtimes_to_test[$runtime]
@@ -54,7 +60,7 @@ function test_cpusoaker() {
 	done
 	if [[ -n "${runtimes_to_test[*]}" ]] ; then
 	    counter=$((counter+1))
-	    namespaces=$((namespaces+1))
+	    replicas=$((replicas+___cpusoaker_replica_increment))
 	else
 	    break
 	fi
@@ -68,11 +74,11 @@ function process_option_cpusoaker() {
     local opt=$1
     read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
     case "$noptname1" in
-	cpusoakerstarting*) ___cpusoaker_starting_namespaces=$optvalue	;;
-	cpusoakerdeps*)     ___cpusoaker_deps_per_namespace=$optvalue	;;
+	cpusoakerstarting*) ___cpusoaker_starting_replicas=$optvalue	;;
+	cpusoakerreplicai*) ___cpusoaker_replica_increment=$optvalue	;;
 	cpusoaker*runtime)  ___cpusoaker_job_runtime=$optvalue		;;
 	cpusoaker*timeout)  ___cpusoaker_job_timeout=$optvalue		;;
-	cpusoakermax*)      ___cpusoaker_max_namespaces=$optvalue	;;
+	cpusoakermax*)      ___cpusoaker_max_replicas=$optvalue		;;
 	*) 		    return 1					;;
     esac
     return 0
@@ -82,13 +88,15 @@ function process_option_cpusoaker() {
 function help_options_cpusoaker() {
     cat <<'EOF'
     CPUsoaker options:
-        --cpusoaker-starting-namespaces=n
+        --cpusoaker-starting-replicas=n
                                 Start the test with the specified number of
-                                namespaces, incrementing until failure.
-                                Default 1.
-        --cpusoaker-deps-per-namespace=n
-                                Deploy the specified number of pods per
-                                namespace.  Default is 5.
+                                replicas, incrementing until failure.
+                                Default 5.
+        --cpusoaker-replica-increment=n
+                                Increment the number of replicas by the
+                                specified number until failure or until
+                                --cpusoaker-max-replicas is reached.  Default
+                                is cpusoaker-starting-replicas.
         --cpusoaker-runtime=seconds
                                 Allow the pods to run for the specified time.
                                 Default is 0.  Typically set to 60 to collect
@@ -96,8 +104,8 @@ function help_options_cpusoaker() {
         --cpusoaker-timeout=seconds
                                 Time the job out after specified time.  Default
                                 is the global timeout default.
-        --cpusoaker-max-namespaces=n
-                                Maximum number of namespaces to scale to.
+        --cpusoaker-max-replicas=n
+                                Maximum number of replicas to scale to.
                                 Default is -1, equivalent to no upper limit.
 EOF
 }

--- a/lib/clusterbuster/CI/workloads/files.workload
+++ b/lib/clusterbuster/CI/workloads/files.workload
@@ -26,7 +26,7 @@ declare -gi ___files_min_direct=1024
 
 register_workload files dispatch_generic
 
-function test_files() {
+function files_test() {
     ___files_job_timeout=$(compute_timeout "$___files_job_timeout")
     if [[ -z "${___files_params[*]}" ]] ; then
 	for ninst in "${___files_ninst[@]}" ; do
@@ -73,7 +73,7 @@ function test_files() {
     done
 }
 
-function process_option_files() {
+function files_process_option() {
     local opt=$1
     read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
     case "$noptname1" in
@@ -90,7 +90,7 @@ function process_option_files() {
     esac
 }
 
-function help_options_files() {
+function files_help_options() {
     cat <<'EOF'
     Files test options:
         --files-timeout=seconds
@@ -127,7 +127,7 @@ function help_options_files() {
 EOF
 }
 
-function document_files() {
+function files_document() {
 cat <<'EOF'
 * files: a simple filesystem stressor that creates and removes a large
   number of files.

--- a/lib/clusterbuster/CI/workloads/files.workload
+++ b/lib/clusterbuster/CI/workloads/files.workload
@@ -64,7 +64,7 @@ function test_files() {
 	job_name="${ninst}P-${___files_dirs_per_volume}D-${___files_per_dir}F-${___files_block_size}B-${file_size}S-${___files_direct}T"
 	# shellcheck disable=SC2090
 	run_clusterbuster -j "$job_name" -w files -t "$___files_job_timeout" -- \
-			  --deployments="$ninst" \
+			  --replicas="$ninst" \
 			  --dirs_per_volume="$___files_dirs_per_volume" \
 			  --files_per_dir="$___files_per_dir" \
 			  --file_block_size="$___files_block_size" \

--- a/lib/clusterbuster/CI/workloads/fio.workload
+++ b/lib/clusterbuster/CI/workloads/fio.workload
@@ -33,7 +33,7 @@ declare -gi ___fio_pod_memsize=
 
 register_workload fio dispatch_generic
 
-function test_fio() {
+function fio_test() {
     local default_job_runtime=$1
     if ((___fio_job_runtime <= 0)) ; then
 	___fio_job_runtime=$default_job_runtime
@@ -78,7 +78,7 @@ function test_fio() {
     done
 }
 
-function process_option_fio() {
+function fio_process_option() {
     local opt=$1
     read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
     case "$noptname1" in
@@ -102,7 +102,7 @@ function process_option_fio() {
     esac
 }
 
-function help_options_fio() {
+function fio_help_options() {
     cat <<'EOF'
    Fio test options:
         --fio-block-sizes=n[,n...]
@@ -154,7 +154,7 @@ function help_options_fio() {
 EOF
 }
 
-function document_fio() {
+function fio_document() {
 cat <<'EOF'
 * fio: a front end for the Flexible I/O tester.
   See https://fio.readthedocs.io/en/latest/fio_doc.html for more

--- a/lib/clusterbuster/CI/workloads/fio.workload
+++ b/lib/clusterbuster/CI/workloads/fio.workload
@@ -64,7 +64,7 @@ function test_fio() {
 	job_name="${ninst}P"
 	# shellcheck disable=SC2090
 	run_clusterbuster -j "$job_name" -w fio -t "$___fio_job_timeout" -R "$___fio_job_runtime" -- \
-			  --deployments="$ninst" \
+			  --replicas="$ninst" \
 			  --fio-blocksize="$(IFS=,; echo "${___fio_blocksizes[*]}")" \
 			  --fio-patterns="$(IFS=,; echo "${___fio_patterns[*]}")" \
 			  --fio-ioengines="$(IFS=,; echo "${___fio_ioengines[*]}")" \

--- a/lib/clusterbuster/CI/workloads/uperf.workload
+++ b/lib/clusterbuster/CI/workloads/uperf.workload
@@ -23,7 +23,7 @@ declare -gi ___uperf_job_timeout=0
 
 register_workload uperf dispatch_generic
 
-function test_uperf() {
+function uperf_test() {
     local default_job_runtime=$1
     if ((___uperf_job_runtime <= 0)) ; then
 	___uperf_job_runtime=$default_job_runtime
@@ -52,7 +52,7 @@ function test_uperf() {
     done
 }
 
-function process_option_uperf() {
+function uperf_process_option() {
     local opt=$1
     read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
     case "$noptname1" in
@@ -67,7 +67,7 @@ function process_option_uperf() {
 }
 
 
-function help_options_uperf() {
+function uperf_help_options() {
     cat <<'EOF'
     Uperf test options:
         --uperf-msg-sizes=n[,n...]
@@ -89,7 +89,7 @@ function help_options_uperf() {
 EOF
 }
 
-function document_uperf() {
+function uperf_document() {
 cat <<'EOF'
 * uperf: a partial front end to uperf (https://www.uperf.org)
 EOF

--- a/lib/clusterbuster/CI/workloads/uperf.workload
+++ b/lib/clusterbuster/CI/workloads/uperf.workload
@@ -40,7 +40,7 @@ function test_uperf() {
 		for test_type in "${___uperf_test_types[@]}" ; do
 		    local job_name="${msg_size}B-${nthr}i-${ninst}P-${test_type}"
 		    run_clusterbuster -j "$job_name" -w uperf -t "$___uperf_job_timeout" -R "$___uperf_job_runtime" -- \
-				      --deployments="$ninst" \
+				      --replicas="$ninst" \
 				      --uperf_msg_size="$msg_size" \
 				      --uperf_test_type="$test_type" \
 				      --uperf_proto=tcp \

--- a/lib/clusterbuster/libclusterbuster.sh
+++ b/lib/clusterbuster/libclusterbuster.sh
@@ -160,9 +160,10 @@ function dispatch_generic() {
     local workload=$1
     local API=$2
     shift 2
-    if type -t "${API}_${workload}" >/dev/null ; then
+    local funcname="${workload}_${API}"
+    if type -t "$funcname" >/dev/null ; then
 	((probe_only)) && return 0
-	"${API}_${workload}" "$@"
+	"$funcname" "$@"
     else
 	return 1
     fi

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -72,7 +72,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
       app: ${namespace}-classic-${instance}
-$(indent 2 standard_labels_yaml "classic" "$namespace" "$instance")
+$(indent 2 standard_labels_yaml "classic" "$namespace" "$instance" 1)
 $(create_spec _create_containers_classic_yaml "$@")
   restartPolicy: Never
 EOF
@@ -85,7 +85,7 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml classic "$namespace" "$instance")
+$(indent 2 standard_labels_yaml classic "$namespace" "$instance" 1)
 spec:
   replicas: $replicas
   selector:
@@ -95,7 +95,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-$(indent 6 standard_labels_yaml "classic" "$namespace" "$instance")
+$(indent 6 standard_labels_yaml "classic" "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
 $(indent 4 create_spec _create_containers_classic_yaml "$@")
 EOF

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -18,7 +18,7 @@
 # Simple workloads (pause pod, clusterbuster, logging)
 ################################################################
 
-function _create_containers_classic_yaml() {
+function _classic_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -56,7 +56,7 @@ EOF
     done
 }
 
-function _create_deployment_classic_yaml() {
+function _classic_create_deployment_yaml() {
     local namespace=$1
     local instance=$2
     if [[ $deployment_type = pod ]] ; then
@@ -73,7 +73,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-classic-${instance}
 $(indent 2 standard_labels_yaml "classic" "$namespace" "$instance" 1)
-$(create_spec _create_containers_classic_yaml "$@")
+$(create_spec _classic_create_containers_yaml "$@")
   restartPolicy: Never
 EOF
 	done
@@ -97,12 +97,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml "classic" "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_classic_yaml "$@")
+$(indent 4 create_spec _classic_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function create_deployment_classic() {
+function classic_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -113,17 +113,17 @@ function create_deployment_classic() {
     local -i instance
     create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_deployment_classic_yaml "$namespace" "$instance" "$secret_count" "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
+	_classic_create_deployment_yaml "$namespace" "$instance" "$secret_count" "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_classic() {
+function classic_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/classic.pl
 EOF
 }
 
-function calculate_logs_required_classic() {
+function classic_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -131,18 +131,18 @@ function calculate_logs_required_classic() {
     echo $((namespaces * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function document_classic() {
+function classic_document() {
     cat <<'EOF'
 * classic: a simple pod based on busybox that logs the date
   once per minute.  Useful for testing the control plane.
 EOF
 }
 
-function workload_reporting_class_classic() {
+function classic_workload_reporting_class() {
     echo generic
 }
 
-function supports_reporting_classic() {
+function classic_supports_reporting() {
     :
 }
 

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -84,7 +84,7 @@ EOF
 	local name="${namespace}-classic-${instance}"
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -59,9 +59,6 @@ EOF
 function _create_deployment_classic_yaml() {
     local namespace=$1
     local instance=$2
-    local secret_count=$3
-    local -i replicas=$4
-    local -i containers_per_pod=$5
     if [[ $deployment_type = pod ]] ; then
 	local -i replica=0
 	while (( replica++ < replicas )) ; do
@@ -74,7 +71,7 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
-      app: ${namespace}-${instance}
+      app: ${namespace}-classic-${instance}
 $(indent 2 standard_labels_yaml "classic" "$namespace" "$instance")
 $(create_spec _create_containers_classic_yaml "$@")
   restartPolicy: Never
@@ -88,12 +85,12 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml classic "$namespace" "$instance")
 spec:
   replicas: $replicas
   selector:
     matchLabels:
-      app: ${namespace}-${instance}
+      app: ${namespace}-classic-${instance}
   strategy:
     type: RollingUpdate
   template:

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -82,7 +82,7 @@ EOF
 	local name=${namespace}-cpusoaker-${instance}
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -85,7 +85,8 @@ apiVersion: apps/v1
 kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
-$(indent 2 standard_deployment_metadata_yaml "$namespace" client)
+$(indent 2 standard_labels_yaml cpusoaker "$namespace" "$instance")
+$(indent 2 standard_deployment_metadata_yaml "$namespace" client 1)
 spec:
   replicas: $replicas
   selector:

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -18,7 +18,7 @@
 # CPU soaker workload
 ################################################################
 
-function _create_containers_cpusoaker_yaml() {
+function _cpusoaker_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -57,7 +57,7 @@ EOF
     done
 }
 
-function _create_cpusoaker_deployment() {
+function _cpusoaker_create_deployment() {
     local namespace=$1
     local instance=$2
     if [[ $deployment_type = pod ]] ; then
@@ -74,7 +74,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-cpusoaker-${instance}
 $(indent 2 standard_labels_yaml cpusoaker "$namespace" "$instance" 1)
-$(create_spec _create_containers_cpusoaker_yaml "$@")
+$(create_spec _cpusoaker_create_containers_yaml "$@")
   restartPolicy: Never
 EOF
 	done
@@ -98,12 +98,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml cpusoaker "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_cpusoaker_yaml "$@")
+$(indent 4 create_spec _cpusoaker_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function create_deployment_cpusoaker() {
+function cpusoaker_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -114,17 +114,17 @@ function create_deployment_cpusoaker() {
     local -i instance
     create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_cpusoaker_deployment "$namespace" "$instance" "$secret_count"  "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
+	_cpusoaker_create_deployment "$namespace" "$instance" "$secret_count"  "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_cpusoaker() {
+function cpusoaker_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/cpusoaker.pl
 EOF
 }
 
-function calculate_logs_required_cpusoaker() {
+function cpusoaker_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -132,13 +132,13 @@ function calculate_logs_required_cpusoaker() {
     echo $((namespaces * processes_per_pod * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function document_cpusoaker() {
+function cpusoaker_document() {
     cat <<'EOF'
 * cpusoaker: a simple CPU soaker running a continuous tight loop.
 EOF
 }
 
-function supports_reporting_cpusoaker() {
+function cpusoaker_supports_reporting() {
     :
 }
 

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -24,7 +24,7 @@ declare -ig ___file_dirs_per_volume=1
 declare -ig ___files_per_dir=1
 declare -ig ___files_direct=0
 
-function _create_containers_files_yaml() {
+function _files_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -32,6 +32,7 @@ function _create_containers_files_yaml() {
     local -i containers_per_pod=$5
     local log_host=${6:-}
     local -i log_port=${7:-0}
+    local replica=${8:+-$8}
     local -i container
     local sync_service=
     local sync_port_num=
@@ -65,7 +66,7 @@ $(indent 2 bootstrap_command_yaml files.pl)
   - "$file_blocks"
   - "$processes_per_pod"
   - "$___files_direct"
-  - "svc-${namespace}-files-${instance}-dc"
+  - "svc-${namespace}-files-${instance}${replica}-dc"
   - "$drop_cache_port"
 $(tmp_volume_paths=("${volume_mount_paths[@]/%/\"}"); IFS=$'\n'; echo "${tmp_volume_paths[*]/#/  - \"}")
 $(emptydirs=("${emptydirs[@]/%/\"}"); IFS=$'\n'; echo "${emptydirs[*]/#/  - \"}")
@@ -74,16 +75,15 @@ EOF
     done
 }
 
-function _create_files_deployment() {
+function _files_create_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
     local -i replicas=$4
-    if [[ $deployment_type = pod ]] ; then
-	local -i replica=0
-	while (( replica++ < replicas )) ; do
-	    local name="${namespace}-files-${instance}-${replica}"
-	    create_object -n "$namespace" "$name"  <<EOF
+    local -i replica=0
+    while (( replica++ < replicas )) ; do
+	local name="${namespace}-files-${instance}-${replica}"
+	create_object -n "$namespace" "$name"  <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -93,36 +93,13 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-files-${instance}
 $(indent 2 standard_labels_yaml files "$namespace" "${instance}-${replica}" 1)
-$(create_spec _create_containers_files_yaml "$@")
+$(create_spec _files_create_containers_yaml "$@" "$replica")
   restartPolicy: Never
 EOF
-	done
-    else
-	local name="${namespace}-files-${instance}"
-	create_object -n "$namespace" "$name" <<EOF
-apiVersion: apps/v1
-kind: $deployment_type
-metadata:
-  name: $(mkpodname "$name")
-$(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml files "$namespace" "$instance" 1)
-spec:
-  replicas: $replicas
-  selector:
-    matchLabels:
-      app: ${namespace}-files-${instance}
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-$(indent 6 standard_labels_yaml files "$namespace" "$instance" 1)
-$(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_files_yaml "$@")
-EOF
-    fi
+    done
 }
 
-function create_deployment_files() {
+function files_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -133,21 +110,16 @@ function create_deployment_files() {
     local -i instance
     create_sync_service_if_needed "$namespace" 8 "$((containers_per_pod * processes_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	if [[ $deployment_type = pod ]] ; then
-	    local -i replica=0
-	    while (( replica++ < replicas )) ; do
-		create_service -H "$namespace" "${namespace}-files-${instance}-${replica}-dc" "$drop_cache_port"
-		create_drop_cache_deployment "$namespace" files "${instance}-${replica}"
-	    done
-	else
-	    create_service -H "$namespace" "${namespace}-files-${instance}-dc" "$drop_cache_port"
-	    create_drop_cache_deployment "$namespace" files "${instance}"
-	fi
-	_create_files_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	local -i replica=0
+	while (( replica++ < replicas )) ; do
+	    create_service -H "$namespace" "${namespace}-files-${instance}-${replica}-dc" "$drop_cache_port"
+	    create_drop_cache_deployment "$namespace" files "${instance}-${replica}"
+	done
+	_files_create_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function calculate_logs_required_files() {
+function files_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -155,16 +127,16 @@ function calculate_logs_required_files() {
     echo $((namespaces * containers_per_pod * processes_per_pod * replicas * deps_per_namespace))
 }
 
-function list_configmaps_files() {
+function files_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/files.pl
 ${__podfile_dir__}/drop_cache.pl
 EOF
 }
 
-function help_options_files() {
+function files_help_options() {
     cat <<'EOF'
-    Using Files:
+    Many Files Options:
        --dirs-per-volume=N
                         Create the specified number of directories per volume.
                         Default 1.
@@ -182,14 +154,14 @@ function help_options_files() {
 EOF
 }
 
-function document_files() {
+function files_document() {
     cat <<'EOF'
 * files: a simple filesystem stressor that creates and removes a large
   number of files.
 EOF
 }
 
-function process_options_files() {
+function files_process_options() {
     local opt
     local -a unknown_opts=()
     for opt in "$@" ; do
@@ -211,15 +183,15 @@ function process_options_files() {
     fi
 }
 
-function supports_reporting_files() {
+function files_supports_reporting() {
     :
 }
 
-function generate_metadata_files() {
-    report_options_files
+function files_generate_metadata() {
+    files_report_options
 }
 
-function report_options_files() {
+function files_report_options() {
     cat <<EOF
 "dirs_per_volume": $___file_dirs_per_volume,
 "files_per_dir": $___files_per_dir,

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -101,7 +101,7 @@ EOF
 	local name="${namespace}-files-${instance}"
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -65,7 +65,7 @@ $(indent 2 bootstrap_command_yaml files.pl)
   - "$file_blocks"
   - "$processes_per_pod"
   - "$___files_direct"
-  - "svc-${namespace}-files-${instance}-${replica}-dc"
+  - "svc-${namespace}-files-${instance}-dc"
   - "$drop_cache_port"
 $(tmp_volume_paths=("${volume_mount_paths[@]/%/\"}"); IFS=$'\n'; echo "${tmp_volume_paths[*]/#/  - \"}")
 $(emptydirs=("${emptydirs[@]/%/\"}"); IFS=$'\n'; echo "${emptydirs[*]/#/  - \"}")
@@ -105,16 +105,18 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
+$(indent 2 standard_labels_yaml files "$namespace" "$instance" 1)
 spec:
   replicas: $replicas
   selector:
     matchLabels:
-      app: ${namespace}-files-$instance
+      app: ${namespace}-files-${instance}
   strategy:
     type: RollingUpdate
   template:
     metadata:
-$(indent 2 standard_labels_yaml files "$namespace" "$instance" 1)
+$(indent 6 standard_labels_yaml files "$namespace" "$instance" 1)
+$(indent 6 standard_pod_metadata_yaml "$namespace" client)
 $(indent 4 create_spec _create_containers_files_yaml "$@")
 EOF
     fi

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -106,7 +106,7 @@ EOF
     else
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -110,6 +110,7 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
+$(indent 2 standard_labels_yaml fio "$namespace" "$instance" 1)
 spec:
   replicas: 1
   selector:

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -32,14 +32,16 @@ declare -g  ___fio_workdir="/tmp"
 declare -g  ___fio_prepare_job_file
 declare -g  ___fio_processed_job_file
 
-function _create_containers_fio_yaml() {
+function _fio_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
-    local -i containers_per_pod=$4
-    local -i processes=$5
-    local log_host=${6:-}
-    local -i log_port=${7:-0}
+    local -i replicas=$4
+    local -i containers_per_pod=$5
+    local -i processes=$6
+    local log_host=${7:-}
+    local -i log_port=${8:-0}
+    local -i replica=$9
     local -i container
     local sync_service=
     local sync_port_num=
@@ -70,7 +72,7 @@ $(indent 2 bootstrap_command_yaml fio.pl)
   - "$___fio_workdir"
   - "$workload_run_time"
   - "$configmap_mount_dir"
-  - "svc-${namespace}-fio-${instance}-dc"
+  - "svc-${namespace}-fio-${instance}-${replica}-dc"
   - "$drop_cache_port"
   - "${___fio_blocksizes[*]:-}"
   - "${___fio_patterns[*]:-}"
@@ -84,12 +86,15 @@ EOF
     done
 }
 
-function _create_fio_deployment() {
+function _fio_create_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
+    local -i replicas=$4
     local name=${namespace}-fio-${instance}
-    if [[ $deployment_type = pod ]] ; then
+    local -i replica=0
+    while (( replica++ < replicas )) ; do
+	local name="${namespace}-files-${instance}-${replica}"
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: v1
 kind: Pod
@@ -98,36 +103,15 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
-      app: ${namespace}-fio-${instance}
-$(indent 2 standard_labels_yaml fio "$namespace" "$instance" 1)
-$(create_spec _create_containers_fio_yaml "$@")
+      app: ${namespace}-fio-${instance}-${replica}
+$(indent 2 standard_labels_yaml fio "$namespace" "${instance}-${replica}" 1)
+$(create_spec _fio_create_containers_yaml "$@" "$replica")
   restartPolicy: Never
 EOF
-    else
-	create_object -n "$namespace" "$name" <<EOF
-apiVersion: apps/v1
-kind: $deployment_type
-metadata:
-  name: $(mkpodname "$name")
-$(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml fio "$namespace" "$instance" 1)
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: ${namespace}-fio-${instance}
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-$(indent 6 standard_labels_yaml fio "$namespace" "$instance" 1)
-$(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_fio_yaml "$@")
-EOF
-    fi
+    done
 }
 
-function create_deployment_fio() {
+function fio_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -139,13 +123,16 @@ function create_deployment_fio() {
     local -i syncs_needed=$((2 + (${#___fio_patterns[@]} * ${#___fio_blocksizes[@]} * ${#___fio_iodepths[@]} * ${#___fio_directs[@]} * ${#___fio_fdatasyncs[@]} * ${#___fio_ioengines[@]}) ))
     create_sync_service_if_needed "$namespace" "$syncs_needed" "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
-	create_service -H "$namespace" "${namespace}-fio-${instance}-dc" "$drop_cache_port"
-	create_drop_cache_deployment "$namespace" fio "$instance"
-	_create_fio_deployment "$namespace" "${instance}" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	local -i replica=0
+	while ((replica++ < replicas)) ; do
+	    create_service -H "$namespace" "${namespace}-fio-${instance}-${replica}-dc" "$drop_cache_port"
+	    create_drop_cache_deployment "$namespace" fio "${instance}-${replica}"
+	done
+	_fio_create_deployment "$namespace" "${instance}" "$secret_count" "$replicas" "$containers_per_pod" "$processes_per_pod" "$log_host" "$log_port"
     done
 }
 
-function calculate_logs_required_fio() {
+function fio_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -153,20 +140,20 @@ function calculate_logs_required_fio() {
     echo $((namespaces * containers_per_pod * processes_per_pod * replicas * deps_per_namespace))
 }
 
-function list_configmaps_fio() {
+function fio_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/fio.pl
 ${__podfile_dir__}/drop_cache.pl
 EOF
 }
 
-function list_user_configmaps_fio() {
+function fio_list_user_configmaps() {
     cat <<EOF
 ${___fio_processed_job_file}
 EOF
 }
 
-function help_options_fio() {
+function fio_help_options() {
     cat <<'EOF'
     Fio Options:
        --fio-patterns=<patterns>
@@ -187,18 +174,18 @@ function help_options_fio() {
                         Name of fio job file to use (defaults to generic).
        --fio-ioengines=<engines>
                         Comma-separated list of names of ioengines to use
-			(default ${___fio_ioenginse[*]})
+                        (default ${___fio_ioenginse[*]})
        --fio-iodepth=<n>
                         Comma-separated list of names of I/O depths to use
                         I/O depth (default ${___fio_iodepths[*]})
        --fio-direct=<directs>
                         Comma-separated list of whether to use direct I/O
-			(default ${___fio_directs[*]}), values are 0 or 1.
+                        (default ${___fio_directs[*]}), values are 0 or 1.
        --fio-ramptime=<ramp time>
                         Ramp-up and down time (default $___fio_ramptime)
        --fio-fdatasync=<fdatasyncs>
                         Comma-separated list of whether to use fdatasync 
-			(default ${___fio_fdatasyncs[*]}), values are 0 or 1.
+                        (default ${___fio_fdatasyncs[*]}), values are 0 or 1.
        --fio-filesize=<size>
                         File size (default $___fio_filesize)
        --fio-workdir=<dir>
@@ -206,7 +193,7 @@ function help_options_fio() {
 EOF
 }
 
-function document_fio() {
+function fio_document() {
     cat <<'EOF'
 * fio: a front end for the Flexible I/O tester.
   See https://fio.readthedocs.io/en/latest/fio_doc.html for more
@@ -214,7 +201,7 @@ function document_fio() {
 EOF
 }
 
-function process_options_fio() {
+function fio_process_options() {
     local opt
     local -a unknown_opts=()
     local fioblksize=
@@ -274,11 +261,11 @@ function process_options_fio() {
     expand_string "$(cat "$___fio_job_file")" > "$___fio_processed_job_file"
 }
 
-function supports_reporting_fio() {
+function fio_supports_reporting() {
     :
 }
 
-function generate_metadata_fio() {
+function fio_generate_metadata() {
     local -a jobs=()
     local -i jobidx=1
     local pattern
@@ -316,7 +303,7 @@ EOF
     echo '}'
 }
 
-function report_options_fio() {
+function fio_report_options() {
     function mk_num_list() {
 	echo "[$(IFS=','; echo "$*")]"
     }

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -89,6 +89,7 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
+$(indent 2 standard_labels_yaml memory "$namespace" "$instance")
 spec:
   replicas: $replicas
   selector:

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -85,7 +85,7 @@ EOF
 	local name=${namespace}-memory-${instance}
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -20,7 +20,7 @@
 
 declare -ig ___memory_size=1048576
 
-function _create_containers_memory_yaml() {
+function _memory_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -60,7 +60,7 @@ EOF
     done
 }
 
-function _create_memory_deployment() {
+function _memory_create_deployment() {
     local namespace=$1
     local instance=$2
     if [[ $deployment_type = pod ]] ; then
@@ -77,7 +77,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-memory-${instance}
 $(indent 2 standard_labels_yaml memory "$namespace" "$instance" 1)
-$(create_spec _create_containers_memory_yaml "$@")
+$(create_spec _memory_create_containers_yaml "$@")
   restartPolicy: Never
 EOF
 	done
@@ -101,12 +101,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml memory "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_memory_yaml "$@")
+$(indent 4 create_spec _memory_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function create_deployment_memory() {
+function memory_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -117,17 +117,17 @@ function create_deployment_memory() {
     local -i instance
     create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_memory_deployment "$namespace" "$instance" "$secret_count"  "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
+	_memory_create_deployment "$namespace" "$instance" "$secret_count"  "$((processes_per_pod))" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_memory() {
+function memory_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/memory.pl
 EOF
 }
 
-function calculate_logs_required_memory() {
+function memory_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -135,13 +135,21 @@ function calculate_logs_required_memory() {
     echo $((namespaces * processes_per_pod * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function document_memory() {
+function memory_document() {
     cat <<'EOF'
 * memory: Allocate a block of memory
 EOF
 }
 
-function process_options_memory() {
+function memory_help_options() {
+    cat <<'EOF'
+    Memory Options:
+       --memory-size=<size>
+                        Amount of memory to allocate
+EOF
+}
+
+function memory_process_options() {
     local opt
     local -a unknown_opts=()
     local fioblksize=
@@ -158,11 +166,11 @@ function process_options_memory() {
     fi
 }
 
-function workload_reporting_class_memory() {
+function memory_workload_reporting_class() {
     echo generic
 }
 
-function supports_reporting_memory() {
+function memory_supports_reporting() {
     :
 }
 

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -20,7 +20,7 @@
 
 declare -ig ___msg_size=32768
 
-function _create_server_server_container_yaml() {
+function _server_create_server_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -44,7 +44,7 @@ $(indent 2 volume_mounts_yaml "$namespace" "$instance" "$secret_count")
 EOF
 }
 
-function _create_server_server_deployment() {
+function _server_create_server_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -60,7 +60,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" server)
     matchLabels:
       app: ${namespace}-server-${instance}
 $(indent 2 standard_labels_yaml server "$namespace" "$instance" )
-$(create_spec -c server _create_server_server_container_yaml "$@")
+$(create_spec -c server _server_create_server_container_yaml "$@")
   restartPolicy: Never
 EOF
     else
@@ -83,12 +83,12 @@ spec:
       labels:
 $(indent 6 standard_labels_yaml server "$namespace" "$instance" )
 $(indent 6 standard_pod_metadata_yaml "$namespace" server)
-$(indent 4 create_spec -c server _create_server_server_container_yaml "$@")
+$(indent 4 create_spec -c server _server_create_server_container_yaml "$@")
 EOF
     fi
 }
 
-function _create_server_client_container_yaml() {
+function _server_create_client_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -136,7 +136,7 @@ EOF
     done
 }
 
-function _create_server_client_affinity_yaml() {
+function _server_create_client_affinity_yaml() {
     (( affinity )) || return 0
     local server=$1
     local affinity_type
@@ -158,12 +158,12 @@ affinity:
 EOF
 }
 
-function _create_server_client_deployment() {
+function _server_create_client_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
     local replicas=$4
-    local affinity_yaml="$(_create_server_client_affinity_yaml "${namespace}-server-${instance}")"
+    local affinity_yaml="$(_server_create_client_affinity_yaml "${namespace}-server-${instance}")"
     if [[ $deployment_type = pod ]] ; then
 	local -i replica=0
 	while (( replica++ < replicas )) ; do
@@ -178,7 +178,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-server-client-${instance}
 $(indent 2 standard_labels_yaml server-client "$namespace" "$instance" 1)
-$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "$replica")
+$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _server_create_client_container_yaml "$@" "$replica")
   restartPolicy: Never
 EOF
 	done
@@ -203,12 +203,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml server-client "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "x")
+$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _server_create_client_container_yaml "$@" "x")
 EOF
     fi
 }
 
-function create_deployment_server() {
+function server_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -222,22 +222,22 @@ function create_deployment_server() {
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_service "$namespace" "${namespace}-server-${instance}" "$port"
 	if [[ $deployment_type = pod ]] ; then
-	    _create_server_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
+	    _server_create_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
 	else
-	    _create_server_server_deployment "$namespace" "$instance" "$secret_count" "-1"
+	    _server_create_server_deployment "$namespace" "$instance" "$secret_count" "-1"
 	fi
-	_create_server_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	_server_create_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_server() {
+function server_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/client.pl
 ${__podfile_dir__}/server.pl
 EOF
 }
 
-function calculate_logs_required_server() {
+function server_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -245,23 +245,23 @@ function calculate_logs_required_server() {
     echo $((namespaces * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function help_options_server() {
+function server_help_options() {
     cat <<'EOF'
-    Client/server options:
-       msgsize         Message size in data transfer
-       pin_node=server=<node>
+    Client/server Options:
+       --msgsize       Message size in data transfer
+       --pin_node=server=<node>
                        Specify node to which the server is bound.
 EOF
 }
 
-function document_server() {
+function server_document() {
     cat <<'EOF'
 * server: a client-server workload with optional bidirectional data
   trasfer, optionally at a specified data rate.
 EOF
 }
 
-function process_options_server() {
+function server_process_options() {
     local opt
     local -a unknown_opts=()
     local ftest
@@ -280,11 +280,11 @@ function process_options_server() {
     fi
 }
 
-function supports_reporting_server() {
+function server_supports_reporting() {
     :
 }
 
-function report_options_server() {
+function server_report_options() {
     cat <<EOF
 "msg_size": $___msg_size
 EOF

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -59,7 +59,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" server)
   selector:
     matchLabels:
       app: ${namespace}-server-${instance}
-$(indent 2 standard_labels_yaml server "$namespace" "$instance" 1)
+$(indent 2 standard_labels_yaml server "$namespace" "$instance" )
 $(create_spec -c server _create_server_server_container_yaml "$@")
   restartPolicy: Never
 EOF
@@ -69,7 +69,7 @@ apiVersion: apps/v1
 kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
-$(indent 2 standard_deployment_metadata_yaml "$namespace" server)
+$(indent 2 standard_deployment_metadata_yaml "$namespace" server )
 $(indent 2 standard_labels_yaml server "$namespace" "$instance")
 spec:
   replicas: 1
@@ -81,7 +81,7 @@ spec:
   template:
     metadata:
       labels:
-$(indent 6 standard_labels_yaml server "$namespace" "$instance" 1)
+$(indent 6 standard_labels_yaml server "$namespace" "$instance" )
 $(indent 6 standard_pod_metadata_yaml "$namespace" server)
 $(indent 4 create_spec -c server _create_server_server_container_yaml "$@")
 EOF
@@ -176,8 +176,8 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
-      app: ${namespace}-client-${instance}
-$(indent 2 standard_labels_yaml client "$namespace" "$instance" 1)
+      app: ${namespace}-server-client-${instance}
+$(indent 2 standard_labels_yaml server-client "$namespace" "$instance" 1)
 $(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "$replica")
   restartPolicy: Never
 EOF
@@ -190,18 +190,18 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml server-client "$namespace" "$instance" 1)
 spec:
   replicas: $replicas
   restartPolicy: Always
   selector:
     matchLabels:
-      app: ${namespace}-client-${instance}
+      app: ${namespace}-server-client-${instance}
   strategy:
     type: RollingUpdate
   template:
     metadata:
-$(indent 6 standard_labels_yaml client "$namespace" "$instance" 1)
+$(indent 6 standard_labels_yaml server-client "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
 $(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "x")
 EOF

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -20,7 +20,7 @@
 
 declare -ig ___msg_size=32768
 
-function _create_server_container_yaml() {
+function _create_server_server_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -44,7 +44,7 @@ $(indent 2 volume_mounts_yaml "$namespace" "$instance" "$secret_count")
 EOF
 }
 
-function _create_server_deployment() {
+function _create_server_server_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -58,9 +58,9 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" server)
   selector:
     matchLabels:
-      app: ${namespace}-${instance}
-$(indent 2 standard_labels_yaml server "$namespace" "$instance")
-$(create_spec -c server _create_server_container_yaml "$@")
+      app: ${namespace}-server-${instance}
+$(indent 2 standard_labels_yaml server "$namespace" "$instance" 1)
+$(create_spec -c server _create_server_server_container_yaml "$@")
   restartPolicy: Never
 EOF
     else
@@ -70,25 +70,25 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" server)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml server "$namespace" "$instance")
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ${namespace}-$instance
+      app: ${namespace}-server-$instance
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-$(indent 6 standard_labels_yaml server "$namespace" "$instance")
+$(indent 6 standard_labels_yaml server "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" server)
-$(indent 4 create_spec -c server _create_server_container_yaml "$@")
+$(indent 4 create_spec -c server _create_server_server_container_yaml "$@")
 EOF
     fi
 }
 
-function _create_client_container_yaml() {
+function _create_server_client_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -136,7 +136,7 @@ EOF
     done
 }
 
-function _create_client_affinity_yaml() {
+function _create_server_client_affinity_yaml() {
     (( affinity )) || return 0
     local server=$1
     local affinity_type
@@ -158,12 +158,12 @@ affinity:
 EOF
 }
 
-function _create_client_deployment() {
+function _create_server_client_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
     local replicas=$4
-    local affinity_yaml="$(_create_client_affinity_yaml "${namespace}-server-${instance}")"
+    local affinity_yaml="$(_create_server_client_affinity_yaml "${namespace}-server-${instance}")"
     if [[ $deployment_type = pod ]] ; then
 	local -i replica=0
 	while (( replica++ < replicas )) ; do
@@ -176,9 +176,9 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
-      app: ${namespace}-${instance}-client
+      app: ${namespace}-client-${instance}
 $(indent 2 standard_labels_yaml client "$namespace" "$instance" 1)
-$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_client_container_yaml "$@" "$replica")
+$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "$replica")
   restartPolicy: Never
 EOF
 	done
@@ -196,14 +196,14 @@ spec:
   restartPolicy: Always
   selector:
     matchLabels:
-      app: ${namespace}-${instance}-client
+      app: ${namespace}-client-${instance}
   strategy:
     type: RollingUpdate
   template:
     metadata:
 $(indent 6 standard_labels_yaml client "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_client_container_yaml "$@" "x")
+$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_server_client_container_yaml "$@" "x")
 EOF
     fi
 }
@@ -222,11 +222,11 @@ function create_deployment_server() {
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_service "$namespace" "${namespace}-server-${instance}" "$port"
 	if [[ $deployment_type = pod ]] ; then
-	    _create_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
+	    _create_server_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
 	else
-	    _create_server_deployment "$namespace" "$instance" "$secret_count" "-1"
+	    _create_server_server_deployment "$namespace" "$instance" "$secret_count" "-1"
 	fi
-	_create_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	_create_server_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -66,7 +66,7 @@ EOF
     else
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" server)
@@ -186,7 +186,7 @@ EOF
 	local name=${namespace}-${instance}-client
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/simple.workload
+++ b/lib/clusterbuster/workloads/simple.workload
@@ -94,7 +94,7 @@ $(indent 2 privilege_yaml)
   selector:
     matchLabels:
       app: ${namespace}-${requested_workload}-${instance}
-$(indent 2 standard_labels_yaml "${requested_workload}" "$namespace" "$instance")
+$(indent 2 standard_labels_yaml "${requested_workload}" "$namespace" "$instance" 1)
 $(create_spec _create_containers_${requested_workload}_yaml "$@")
 EOF
 	done
@@ -107,7 +107,7 @@ metadata:
   name: $(mkpodname "$name")
 $(indent 2 namespace_yaml "$namespace")
 $(indent 2 privilege_yaml)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml "${requested_workload}" "$namespace" "$instance" 1)
 spec:
   replicas: $replicas
   selector:
@@ -117,7 +117,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-$(indent 6 standard_labels_yaml "${requested_workload}" "$namespace" "$instance")
+$(indent 6 standard_labels_yaml "${requested_workload}" "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
 $(indent 4 create_spec _create_containers_${requested_workload}_yaml "$@")
 EOF

--- a/lib/clusterbuster/workloads/simple.workload
+++ b/lib/clusterbuster/workloads/simple.workload
@@ -93,7 +93,7 @@ $(indent 2 namespace_yaml "$namespace")
 $(indent 2 privilege_yaml)
   selector:
     matchLabels:
-      app: ${namespace}-${instance}
+      app: ${namespace}-${requested_workload}-${instance}
 $(indent 2 standard_labels_yaml "${requested_workload}" "$namespace" "$instance")
 $(create_spec _create_containers_${requested_workload}_yaml "$@")
 EOF
@@ -112,12 +112,13 @@ spec:
   replicas: $replicas
   selector:
     matchLabels:
-      app: ${namespace}-${instance}
+      app: ${namespace}-${requested_workload}-${instance}
   strategy:
     type: RollingUpdate
   template:
     metadata:
 $(indent 6 standard_labels_yaml "${requested_workload}" "$namespace" "$instance")
+$(indent 6 standard_pod_metadata_yaml "$namespace" client)
 $(indent 4 create_spec _create_containers_${requested_workload}_yaml "$@")
 EOF
     fi

--- a/lib/clusterbuster/workloads/simple.workload
+++ b/lib/clusterbuster/workloads/simple.workload
@@ -25,7 +25,7 @@ declare -ig ___log_processes=1
 declare -ig ___log_delay_usec=0
 declare -ig ___log_xfertime=0
 
-function _create_containers_pausepod_yaml() {
+function _simple-pausepod_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -43,7 +43,7 @@ EOF
     done
 }
 
-function _create_containers_log_yaml() {
+function _simple-log_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -74,7 +74,7 @@ $(indent 2 volume_mounts_yaml "$namespace" "${instance}" "$secret_count")
 EOF
     done
 }
-function _create_deployment_simple_yaml() {
+function _simple_create_deployment_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -95,7 +95,8 @@ $(indent 2 privilege_yaml)
     matchLabels:
       app: ${namespace}-${requested_workload}-${instance}
 $(indent 2 standard_labels_yaml "${requested_workload}" "$namespace" "$instance" 1)
-$(create_spec _create_containers_${requested_workload}_yaml "$@")
+$(create_spec _${requested_workload}_create_containers_yaml "$@")
+  restartPolicy: Never
 EOF
 	done
     else
@@ -119,12 +120,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml "${requested_workload}" "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_${requested_workload}_yaml "$@")
+$(indent 4 create_spec _${requested_workload}_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function _create_deployment_simple() {
+function _simple_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -133,38 +134,38 @@ function _create_deployment_simple() {
     local -i instance
     create_sync_service_if_needed "$namespace" 0 $((replicas * (count + first_deployment)))
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_deployment_simple_yaml "$namespace" "${instance}" "$secret_count"  "$replicas" "$containers_per_pod"
+	_simple_create_deployment_yaml "$namespace" "${instance}" "$secret_count"  "$replicas" "$containers_per_pod"
     done
 }
 
 # The simple workloads do not support logging or synchronization.
 # The Log workload is about log generation
 
-function supports_reporting_simple() {
+function simple-log_supports_reporting() {
     :
 }
 
-function supports_reporting_pausepod() {
+function simple-pausepod_supports_reporting() {
     :
 }
 
-function list_configmaps_simple() {
+function simple-log_list_configmaps() {
     :
 }
 
-function list_configmaps_pausepod() {
+function simple-pausepod_list_configmaps() {
     :
 }
 
-function workload_reporting_class_simple() {
+function simple-log_workload_reporting_class() {
     echo generic_nodata
 }
 
-function workload_reporting_class_pausepod() {
+function simple-pausepod_workload_reporting_class() {
     echo generic_nodata
 }
 
-function calculate_logs_required_simple() {
+function _simple_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -172,25 +173,29 @@ function calculate_logs_required_simple() {
     echo $((namespaces * replicas * deps_per_namespace))
 }
 
-function calculate_logs_required_pausepod() {
-    calculate_logs_required_simple "$@"
+function simple-log_calculate_logs_required() {
+    _simple_calculate_logs_required "$@"
 }
 
-function list_configmaps_log() {
+function simple-pausepod_calculate_logs_required() {
+    _simple_calculate_logs_required "$@"
+}
+
+function simple-log_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/logger.pl
 EOF
 }
 
-function create_deployment_pausepod() {
-    _create_deployment_simple "$@"
+function simple-pausepod_create_deployment() {
+    _simple_create_deployment "$@"
 }
 
-function create_deployment_log() {
-    _create_deployment_simple "$@"
+function simple-log_create_deployment() {
+    _simple_create_deployment "$@"
 }
 
-function help_options_log() {
+function simple-log_help_options() {
     cat <<EOF
     Log Options:
        --log-bytes-per-line=<bytes_per_line>
@@ -215,7 +220,7 @@ function help_options_log() {
 EOF
 }
 
-function document_pausepod() {
+function simple-pausepod_document() {
     cat <<'EOF'
 * pausepod: a minimal pod that does nothing.  Useful for stressing
   the control plane.  See
@@ -223,13 +228,13 @@ function document_pausepod() {
 EOF
 }
 
-function document_log() {
+function simple-log_document() {
     cat <<'EOF'
 * log: a pod that emits log messages at a controllable rate.
 EOF
 }
 
-function process_options_log() {
+function simple-log_process_options() {
     local opt
     local -a unknown_opts=()
     for opt in "$@" ; do
@@ -249,7 +254,7 @@ function process_options_log() {
     fi
 }
 
-function report_options_log() {
+function simple-log_report_options() {
     cat <<EOF
 "log_bytes_per_line": $___log_bytes_per_line,
 "log_bytes_per_io": $___log_bytes_per_io,
@@ -260,5 +265,5 @@ function report_options_log() {
 EOF
 }
 
-register_workload pausepod dispatch_generic pause
-register_workload log dispatch_generic logger logging
+register_workload simple-pausepod dispatch_generic pausepod pause
+register_workload simple-log dispatch_generic log logger logging

--- a/lib/clusterbuster/workloads/simple.workload
+++ b/lib/clusterbuster/workloads/simple.workload
@@ -102,7 +102,7 @@ EOF
 	local name="${namespace}-${requested_workload}-${instance}"
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 namespace_yaml "$namespace")

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -23,7 +23,7 @@ declare -g ___synctest_count=5
 declare -g ___synctest_cluster_count=1
 declare -g ___synctest_sleep=0
 
-function _create_containers_synctest_yaml() {
+function _synctest_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -66,7 +66,7 @@ EOF
     done
 }
 
-function _create_synctest_deployment() {
+function _synctest_create_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -82,7 +82,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-synctest-${instance}
 $(indent 2 standard_labels_yaml synctest "$namespace" "$instance" 1)
-$(create_spec _create_containers_synctest_yaml "$@")
+$(create_spec _synctest_create_containers_yaml "$@")
   restartPolicy: Never
 EOF
     else
@@ -104,12 +104,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml synctest "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_synctest_yaml "$@")
+$(indent 4 create_spec _synctest_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function create_deployment_synctest() {
+function synctest_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -120,17 +120,17 @@ function create_deployment_synctest() {
     local -i instance
     create_sync_service_if_needed "$namespace" "$(((___synctest_count * ___synctest_cluster_count) + 2))" "$((containers_per_pod * replicas * processes_per_pod * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_synctest_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	_synctest_create_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_synctest() {
+function synctest_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/synctest.pl
 EOF
 }
 
-function help_options_synctest() {
+function synctest_help_options() {
     cat <<'EOF'
     Synctest General Options:
        --synctest-count=n
@@ -142,13 +142,13 @@ function help_options_synctest() {
 EOF
 }
 
-function document_synctest() {
+function synctest_document() {
     cat <<'EOF'
 * synctest: tests internal sync
 EOF
 }
 
-function process_options_synctest() {
+function synctest_process_options() {
     local opt
     local -a unknown_opts=()
     local ftest
@@ -167,7 +167,7 @@ function process_options_synctest() {
     fi
 }
 
-function calculate_logs_required_synctest() {
+function synctest_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -175,18 +175,18 @@ function calculate_logs_required_synctest() {
     echo $((namespaces * processes_per_pod * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function report_options_synctest() {
+function synctest_report_options() {
     cat <<EOF
 "synctest_count": $___synctest_count,
 "synctest_sleep": $___synctest_sleep
 EOF
 }
 
-function workload_reporting_class_synctest() {
+function synctest_workload_reporting_class() {
     echo generic
 }
 
-function supports_reporting_synctest() {
+function synctest_supports_reporting() {
     :
 }
 

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -88,7 +88,7 @@ EOF
     else
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -92,7 +92,7 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml synctest "$namespace" "$instance" 1)
 spec:
   replicas: 1
   selector:

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -101,7 +101,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ${namespace}-sysbench-$instance
+      app: ${namespace}-sysbench-${instance}
   strategy:
     type: RollingUpdate
   template:

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -24,7 +24,7 @@ declare -ag ___sysbench_fileio_options=()
 declare -Ag ___sysbench_fileio_tests=()
 declare -g ___sysbench_fileio_test_string='seqwr,seqrd,rndwr,rndrd'
 
-function _create_containers_sysbench_yaml() {
+function _sysbench_create_containers_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -70,7 +70,7 @@ EOF
     done
 }
 
-function _create_sysbench_deployment() {
+function _sysbench_create_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -86,7 +86,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-sysbench-${instance}
 $(indent 2 standard_labels_yaml sysbench "$namespace" "$instance" 1)
-$(create_spec _create_containers_sysbench_yaml "$@")
+$(create_spec _sysbench_create_containers_yaml "$@")
   restartPolicy: Never
 EOF
     else
@@ -108,12 +108,12 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml sysbench "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec _create_containers_sysbench_yaml "$@")
+$(indent 4 create_spec _sysbench_create_containers_yaml "$@")
 EOF
     fi
 }
 
-function create_deployment_sysbench() {
+function sysbench_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -124,17 +124,17 @@ function create_deployment_sysbench() {
     local -i instance
     create_sync_service_if_needed "$namespace" "$(( (${#___sysbench_fileio_tests[@]} * 3) + 2))" "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
-	_create_sysbench_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	_sysbench_create_deployment "$namespace" "$instance" "$secret_count"  "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_sysbench() {
+function sysbench_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/sysbench.pl
 EOF
 }
 
-function calculate_logs_required_sysbench() {
+function sysbench_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -142,7 +142,7 @@ function calculate_logs_required_sysbench() {
     echo $((namespaces * containers_per_pod * processes_per_pod * replicas * deps_per_namespace))
 }
 
-function help_options_sysbench() {
+function sysbench_help_options() {
     cat <<'EOF'
     Sysbench General Options:
        --sysbench-general-options=<options>
@@ -159,7 +159,7 @@ function help_options_sysbench() {
 EOF
 }
 
-function document_sysbench() {
+function sysbench_document() {
     cat <<'EOF'
 * sysbench: scriptable multi-threaded benchmark tool based on LuaJIT.
   Currently supports only file I/O operations.
@@ -167,7 +167,7 @@ function document_sysbench() {
 EOF
 }
 
-function process_options_sysbench() {
+function sysbench_process_options() {
     local opt
     local -a unknown_opts=()
     local ftest
@@ -190,11 +190,11 @@ function process_options_sysbench() {
     done
 }
 
-function supports_reporting_sysbench() {
+function sysbench_supports_reporting() {
     :
 }
 
-function report_options_sysbench() {
+function sysbench_report_options() {
     cat <<EOF
 "sysbench_general_options": [$(quote_list "${___sysbench_general_options[@]}")],
 "sysbench_Generic_options": [$(quote_list "${___sysbench_generic_options[@]}")],

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -96,7 +96,7 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml sysbench "$namespace" "$instance" 1)
 spec:
   replicas: 1
   selector:

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -92,7 +92,7 @@ EOF
     else
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -27,7 +27,7 @@ declare -gir ___uperf_port=30000
 declare -gir ___uperf_port_addrs=24
 declare -gi ___uperf_ramp_time=3
 
-function _create_uperf_server_container_yaml() {
+function _uperf_create_server_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -47,7 +47,7 @@ $(indent 2 volume_mounts_yaml "$namespace" "$instance" "$secret_count")
 EOF
 }
 
-function _create_uperf_security_context() {
+function _uperf_create_security_context() {
     cat <<EOF
 securityContext:
   sysctls:
@@ -56,7 +56,7 @@ securityContext:
 EOF
 }
 
-function _create_uperf_server_deployment() {
+function _uperf_create_server_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -71,20 +71,20 @@ $(indent 2 standard_all_metadata_yaml "$namespace" server)
     matchLabels:
       app: ${namespace}-${instance}
 $(indent 2 standard_labels_yaml uperf-server "$namespace" "$instance")
-$(create_spec -c server _create_uperf_server_container_yaml "$@")
+$(create_spec -c server _uperf_create_server_container_yaml "$@")
   restartPolicy: Never
-$(indent 2 _create_uperf_security_context)
+$(indent 2 _uperf_create_security_context)
 EOF
 }
 
-function _create_uperf_tests() {
+function _uperf_create_tests() {
     local test
     for test in "$@" ; do
 	echo "- \"$test\""
     done
 }
 
-function _create_uperf_client_container_yaml() {
+function _uperf_create_client_container_yaml() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -119,13 +119,13 @@ $(indent 2 bootstrap_command_yaml uperf-client.pl)
   - "$___uperf_ramp_time"
   - "svc-${namespace}-uperf-server-$instance"
   - "$___uperf_port"
-$(indent 2 _create_uperf_tests "${___uperf_tests[@]}")
+$(indent 2 _uperf_create_tests "${___uperf_tests[@]}")
 $(indent 2 volume_mounts_yaml "$namespace" "$instance" "$secret_count")
 EOF
     done
 }
 
-function _create_uperf_client_affinity_yaml() {
+function _uperf_create_client_affinity_yaml() {
     (( affinity )) || return 0
     local server=$1
     local affinity_type
@@ -147,12 +147,12 @@ affinity:
 EOF
 }
 
-function _create_uperf_client_deployment() {
+function _uperf_create_client_deployment() {
     local namespace=$1
     local instance=$2
     local secret_count=$3
     local replicas=$4
-    local affinity_yaml="$(_create_uperf_client_affinity_yaml "${namespace}-uperf-server-${instance}")"
+    local affinity_yaml="$(_uperf_create_client_affinity_yaml "${namespace}-uperf-server-${instance}")"
     if [[ $deployment_type = pod ]] ; then
 	local -i replica=0
 	while (( replica++ < replicas )) ; do
@@ -167,9 +167,9 @@ $(indent 2 standard_all_metadata_yaml "$namespace" client)
     matchLabels:
       app: ${namespace}-uperf-client-${instance}
 $(indent 2 standard_labels_yaml uperf-client "$namespace" "$instance" 1)
-$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_uperf_client_container_yaml "$@" "$replica")
+$(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _uperf_create_client_container_yaml "$@" "$replica")
   restartPolicy: Never
-$(indent 2 _create_uperf_security_context)
+$(indent 2 _uperf_create_security_context)
 EOF
 	done
     else
@@ -193,13 +193,13 @@ spec:
     metadata:
 $(indent 6 standard_labels_yaml uperf-client "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_uperf_client_container_yaml "$@" "x")
-$(indent 6 _create_uperf_security_context)
+$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _uperf_create_client_container_yaml "$@" "x")
+$(indent 6 _uperf_create_security_context)
 EOF
     fi
 }
 
-function create_deployment_uperf() {
+function uperf_create_deployment() {
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}
@@ -213,15 +213,15 @@ function create_deployment_uperf() {
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_service "$namespace" "${namespace}-uperf-server-${instance}" $(seq "$___uperf_port" $((___uperf_port + ___uperf_port_addrs)))
 	if [[ $deployment_type = pod ]] ; then
-	    _create_uperf_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
+	    _uperf_create_server_deployment "$namespace" "$instance" "$secret_count" "$((containers_per_pod * replicas))"
 	else
-	    _create_uperf_server_deployment "$namespace" "$instance" "$secret_count" "-1"
+	    _uperf_create_server_deployment "$namespace" "$instance" "$secret_count" "-1"
 	fi
-	_create_uperf_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
+	_uperf_create_client_deployment "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod" "$log_host" "$log_port"
     done
 }
 
-function list_configmaps_uperf() {
+function uperf_list_configmaps() {
     cat <<EOF
 ${__podfile_dir__}/uperf-client.pl
 ${__podfile_dir__}/uperf-server.pl
@@ -231,7 +231,7 @@ ${__podfile_dir__}/uperf-stream.xml
 EOF
 }
 
-function calculate_logs_required_uperf() {
+function uperf_calculate_logs_required() {
     local -i namespaces=$1
     local -i deps_per_namespace=${2:-1}
     local -i replicas=${3:-1}
@@ -239,30 +239,34 @@ function calculate_logs_required_uperf() {
     echo $((namespaces * containers_per_pod * replicas * deps_per_namespace))
 }
 
-function help_options_uperf() {
+function uperf_help_options() {
     cat <<'EOF'
-    uperf options:
-       workload-runtime
+    Uperf Options:
+       --workload-runtime
                        How many seconds to run each test for.
-       pin_node=server=<node>
+       --pin_node=server=<node>
                        Specify node to which the server is bound.
-      The following options take a comma-separated list of each
-      value to test.  The outer product of all specified tests
-      is run.
-       uperf-msg-size  Specify the message size(s) to be tested.
-       uperf-test-type Type of test to run (currently stream or rr)
-       uperf-protocol  Protocol (tcp or udp).
-       uperf-nthr      Number of threads to be tested.
+     The following options take a comma-separated list of each
+     value to test.  The outer product of all specified tests
+     is run.
+       --uperf-msg-size=<sizes>
+                       Specify the message size(s) to be tested.
+       --uperf-test-type=<types>
+                       Type of test to run (currently stream or rr)
+       --uperf-protocol=protocol
+                       Protocol (tcp or udp).
+       --uperf-nthr=<n>
+                       Number of threads to be tested.
 EOF
 }
 
-function document_uperf() {
+function uperf_document() {
     cat <<'EOF'
 * uperf: a partial front end to uperf (https://www.uperf.org)
 EOF
 }
 
-function process_options_uperf() {
+function uperf_process_options() {
     local opt
     local -a unknown_opts=()
     for opt in "$@" ; do
@@ -302,11 +306,11 @@ function process_options_uperf() {
     done
 }
 
-function supports_reporting_uperf() {
+function uperf_supports_reporting() {
     :
 }
 
-function generate_metadata_uperf() {
+function uperf_generate_metadata() {
     local -a jobs=()
     local -i jobidx=1
     local -i msgsize
@@ -338,7 +342,7 @@ EOF
     echo '}'
 }
 
-function report_options_uperf() {
+function uperf_report_options() {
     cat <<EOF
 "msg_size": $___msg_size
 EOF

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -173,7 +173,7 @@ EOF
 	local name=${namespace}-${instance}-client
 	create_object -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
-kind: Deployment
+kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -47,6 +47,15 @@ $(indent 2 volume_mounts_yaml "$namespace" "$instance" "$secret_count")
 EOF
 }
 
+function _create_uperf_security_context() {
+    cat <<EOF
+securityContext:
+  sysctls:
+  - name: net.ipv4.ip_local_port_range
+    value: $___uperf_port $((___uperf_port + ___uperf_port_addrs))
+EOF
+}
+
 function _create_uperf_server_deployment() {
     local namespace=$1
     local instance=$2
@@ -64,10 +73,7 @@ $(indent 2 standard_all_metadata_yaml "$namespace" server)
 $(indent 2 standard_labels_yaml uperf-server "$namespace" "$instance")
 $(create_spec -c server _create_uperf_server_container_yaml "$@")
   restartPolicy: Never
-  securityContext:
-    sysctls:
-    - name: net.ipv4.ip_local_port_range
-      value: $___uperf_port $((___uperf_port + ___uperf_port_addrs))
+$(indent 2 _create_uperf_security_context)
 EOF
 }
 
@@ -146,7 +152,7 @@ function _create_uperf_client_deployment() {
     local instance=$2
     local secret_count=$3
     local replicas=$4
-    local affinity_yaml="$(_create_client_affinity_yaml "${namespace}-uperf-server-${instance}")"
+    local affinity_yaml="$(_create_uperf_client_affinity_yaml "${namespace}-uperf-server-${instance}")"
     if [[ $deployment_type = pod ]] ; then
 	local -i replica=0
 	while (( replica++ < replicas )) ; do
@@ -159,14 +165,11 @@ metadata:
 $(indent 2 standard_all_metadata_yaml "$namespace" client)
   selector:
     matchLabels:
-      app: ${namespace}-${instance}-uperf-client
+      app: ${namespace}-uperf-client-${instance}
 $(indent 2 standard_labels_yaml uperf-client "$namespace" "$instance" 1)
 $(create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_uperf_client_container_yaml "$@" "$replica")
   restartPolicy: Never
-  securityContext:
-    sysctls:
-    - name: net.ipv4.ip_local_port_range
-      value: $___uperf_port $((___uperf_port + ___uperf_port_addrs))
+$(indent 2 _create_uperf_security_context)
 EOF
 	done
     else
@@ -177,24 +180,21 @@ kind: $deployment_type
 metadata:
   name: $(mkpodname "$name")
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
-$(indent 2 standard_labels_yaml)
+$(indent 2 standard_labels_yaml uperf-client "$namespace" "$instance" 1)
 spec:
   replicas: $replicas
   restartPolicy: Always
   selector:
     matchLabels:
-      app: ${namespace}-${instance}-client
+      app: ${namespace}-uperf-client-${instance}
   strategy:
     type: RollingUpdate
   template:
     metadata:
-$(indent 6 standard_labels_yaml client "$namespace" "$instance" 1)
+$(indent 6 standard_labels_yaml uperf-client "$namespace" "$instance" 1)
 $(indent 6 standard_pod_metadata_yaml "$namespace" client)
-$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_client_container_yaml "$@" "x")
-      securityContext:
-	sysctls:
-	- name: net.ipv4.ip_local_port_range
-          value: $___uperf_port $((___uperf_port + ___uperf_port_addrs))
+$(indent 4 create_spec ${affinity_yaml:+-A "$affinity_yaml"} _create_uperf_client_container_yaml "$@" "x")
+$(indent 6 _create_uperf_security_context)
 EOF
     fi
 }


### PR DESCRIPTION
This is more efficient at creating pods, but it also thrashes nodes, so I may not be able to merge this.