### PR TITLE
Generalize how command line options are generated

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -1639,6 +1639,23 @@ EOF
     fi
 }
 
+function mk_cli_args() {
+    local OPTARG
+    local OPTIND=0
+    local -a answers=()
+    while getopts 's' opt "$@" ; do
+	case "$opt" in
+	    s)
+		readarray -t answers
+		;;
+	    *)
+		;;
+	esac
+    done
+    answers+=("$@")
+    echo "${answers[*]}"
+}
+
 function mk_yaml_args() {
     function yamlize() {
 	local arg=$1
@@ -1708,7 +1725,7 @@ $(indent 2 container_standard_auxiliary_yaml)
     value: "$verbose"
 $(indent 2 bootstrap_command_yaml "$node_executable")
 $(indent 2 standard_yaml_args "$namespace" "$container")
-$(if [[ -n "${arglist_function}" ]] ; then "${arglist_function}" "$@" "$container" | indent 2 ; fi)
+$(if [[ -n "${arglist_function}" ]] ; then "${arglist_function}" mk_yaml_args "$@" "$container" | indent 2 ; fi)
 $(indent 2 volume_mounts_yaml "$namespace" "${instance}" "$secret_count")
 EOF
     done
@@ -2469,7 +2486,7 @@ function create_standard_deployment() {
     if (($# != 5)) ; then
 	fatal "Usage: create_standard_deployment <args> namespace instance secret_count replicas containers"
     fi
-    
+
     case "${deployment_type,,}" in
 	single_pod)
 	    create_single_pod_deployment "$@"

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -19,7 +19,8 @@
 ################################################################
 
 function classic_arglist() {
-    mk_yaml_args "${workload_run_time:-10}"
+    local mk_args_func="$1"; shift
+    "$mk_args_func" "${workload_run_time:-10}"
 }
 
 function classic_create_deployment() {

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -19,7 +19,8 @@
 ################################################################
 
 function cpusoaker_arglist() {
-    mk_yaml_args "$processes_per_pod" "$workload_run_time"
+    local mk_args_func="$1"; shift
+    "$mk_args_func" "$processes_per_pod" "$workload_run_time"
 }
 
 function cpusoaker_create_deployment() {

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -25,6 +25,7 @@ declare -ig ___files_per_dir=1
 declare -ig ___files_direct=0
 
 function files_arglist() {
+    local mk_args_func="$1"; shift
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -32,9 +33,9 @@ function files_arglist() {
     local containers_per_pod=$5
     local -i file_blocks=$((___file_size/___file_block_size))
     local mounts=("${volume_mount_paths[@]}" "${emptydirs[@]}")
-    mk_yaml_args "$___file_dirs_per_volume" "$___files_per_dir" "$___file_block_size" "$file_blocks" \
-		 "$processes_per_pod" "$___files_direct" "svc-${namespace}-files-${instance}-${replica}-dc" \
-		 "$drop_cache_port" "${mounts[@]}"
+    "$mk_args_func" "$___file_dirs_per_volume" "$___files_per_dir" "$___file_block_size" "$file_blocks" \
+		    "$processes_per_pod" "$___files_direct" "svc-${namespace}-files-${instance}-${replica}-dc" \
+		    "$drop_cache_port" "${mounts[@]}"
 }
 
 function files_create_deployment() {

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -33,16 +33,17 @@ declare -g  ___fio_prepare_job_file
 declare -g  ___fio_processed_job_file
 
 function fio_arglist() {
+    local mk_args_func="$1"; shift
     local namespace=$1
     local instance=$2
     local secret_count=$3
     local replicas=$4
     local containers_per_pod=$5
-    mk_yaml_args "$processes_per_pod" "$___fio_workdir" "$workload_run_time" "$configmap_mount_dir" \
-		 "svc-${namespace}-fio-${instance}-${replica}-dc" "$drop_cache_port" \
-		 "${___fio_blocksizes[*]:-}" "${___fio_patterns[*]:-}" "${___fio_iodepths[*]:-}" \
-		 "${___fio_fdatasyncs[*]:-}" "${___fio_directs[*]:-}" "${___fio_ioengines[*]:-}" \
-		 "${___fio_generic_options[*]:-}"
+    "$mk_args_func" "$processes_per_pod" "$___fio_workdir" "$workload_run_time" "$configmap_mount_dir" \
+		    "svc-${namespace}-fio-${instance}-${replica}-dc" "$drop_cache_port" \
+		    "${___fio_blocksizes[*]:-}" "${___fio_patterns[*]:-}" "${___fio_iodepths[*]:-}" \
+		    "${___fio_fdatasyncs[*]:-}" "${___fio_directs[*]:-}" "${___fio_ioengines[*]:-}" \
+		    "${___fio_generic_options[*]:-}"
 }
 
 function fio_create_deployment() {

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -21,7 +21,8 @@
 declare -ig ___memory_size=1048576
 
 function memory_arglist() {
-    mk_yaml_args "$processes_per_pod" "$___memory_size" "$workload_run_time"
+    local mk_args_func="$1"; shift
+    "$mk_args_func" "$processes_per_pod" "$___memory_size" "$workload_run_time"
 }
 
 function memory_create_deployment() {

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -21,19 +21,21 @@
 declare -ig ___msg_size=32768
 
 function server_server_arglist() {
+    local mk_args_func="$1"; shift
     local replicas=$4
-    mk_yaml_args "$port" "$___msg_size" "$(ts)" "$((containers_per_pod * replicas))"
+    "$mk_args_func" "$port" "$___msg_size" "$(ts)" "$((containers_per_pod * replicas))"
 }
 
 function server_client_arglist() {
+    local mk_args_func="$1"; shift
     local namespace=$1
     local instance=$2
     if [[ $target_data_rate != 0 && $target_data_rate != '' && $workload_run_time_max -eq 0 && bytes_transfer_max -eq 0 ]] ; then
 	bytes_transfer=$default_bytes_transfer
 	bytes_transfer_max=$default_bytes_transfer
     fi
-    mk_yaml_args "svc-${namespace}-server-server-$instance" "$port" "$target_data_rate" "$bytes_transfer" \
-		 "$bytes_transfer_max" "$___msg_size" "$workload_run_time" "$workload_run_time_max"
+    "$mk_args_func" "svc-${namespace}-server-server-$instance" "$port" "$target_data_rate" "$bytes_transfer" \
+		    "$bytes_transfer_max" "$___msg_size" "$workload_run_time" "$workload_run_time_max"
 }
 
 function server_create_deployment() {

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -24,10 +24,11 @@ declare -g ___synctest_cluster_count=1
 declare -g ___synctest_sleep=0
 
 function synctest_create_containers_yaml() {
-    mk_yaml_args "$___synctest_count" "$___synctest_cluster_count" "$___synctest_sleep"
+    "$mk_args_func" "$___synctest_count" "$___synctest_cluster_count" "$___synctest_sleep"
 }
 
 function synctest_create_deployment() {
+    local mk_args_func="$1"; shift
     local namespace=$1
     local count=${2:-1}
     local secret_count=${3:-1}

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -25,10 +25,11 @@ declare -Ag ___sysbench_fileio_tests=()
 declare -g ___sysbench_fileio_test_string='seqwr,seqrd,rndwr,rndrd'
 
 function sysbench_arglist() {
+    local mk_args_func="$1"; shift
     local workdir=${common_workdir:-${emptydirs[0]:-/tmp}}
-    mk_yaml_args "$processes_per_pod" "$workdir" "$workload_run_time" \
-		 "${___sysbench_generic_options[*]:-}" "fileio" \
-		 "${___sysbench_fileio_options[*]:-}" "${!___sysbench_fileio_tests[*]}"
+    "$mk_args_func" "$processes_per_pod" "$workdir" "$workload_run_time" \
+		    "${___sysbench_generic_options[*]:-}" "fileio" \
+		    "${___sysbench_fileio_options[*]:-}" "${!___sysbench_fileio_tests[*]}"
 }
 
 function sysbench_create_deployment() {

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -28,7 +28,8 @@ declare -gir ___uperf_port_addrs=24
 declare -gi ___uperf_ramp_time=3
 
 function uperf_server_arglist() {
-    mk_yaml_args "$___uperf_port"
+    local mk_args_func="$1"; shift
+    "$mk_args_func" "$___uperf_port"
 }
 
 function _uperf_create_security_context() {
@@ -41,8 +42,9 @@ EOF
 }
 
 function uperf_client_arglist() {
-    mk_yaml_args "$workload_run_time" "$___uperf_ramp_time" "svc-${namespace}-uperf-server-$instance" \
-		 "$___uperf_port" "${___uperf_tests[@]}"
+    local mk_args_func="$1"; shift
+    "$mk_args_func" "$workload_run_time" "$___uperf_ramp_time" "svc-${namespace}-uperf-server-$instance" \
+		    "$___uperf_port" "${___uperf_tests[@]}"
 }
 
 function uperf_create_deployment() {


### PR DESCRIPTION
This should assist adding support for VMs.

Tested as follows:

```
$ cd examples/clusterbuster
$ for w in [a-z]* ; do echo $w; clusterbuster -f "$w" || break; done
$ for w in [a-z]* ; do echo $w; clusterbuster -f "$w" --deployment-type=rs || break; done
$ run-kata-perf-suite --force-abort --artifactdir=/var/tmp/d11 --profile=test_ci --no-cleanup --deployment-type=pod
$ run-kata-perf-suite --force-abort --artifactdir=/var/tmp/d11 --profile=test_ci --no-cleanup --deployment-type=rs
```