### PR TITLE
Detect failure of multi-process pods and fail

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -157,6 +157,7 @@ declare -i liveness_probe_sleep_time=0
 declare pod_prefix=
 
 declare -r sync_flag_file="/tmp/syncfile";
+declare -r sync_error_file="/tmp/syncerror";
 declare -r controller_timestamp_file="/tmp/timing.json";
 # shellcheck disable=2155
 declare uuid=$(uuidgen -r)
@@ -1238,7 +1239,50 @@ function run_logger() {
     fi
 }
 
+# Use a separate flag file for errors to simplify the logic.
+# This way we can send correct output to stdout, but handle
+# errors in a separate subprocess.
+function _fail_helper()  {
+    trap exit TERM
+    local faildata
+    while : ; do
+	local podstatus
+	podstatus=$("$OC" get pod -ojsonpath='{.status.phase}' "$@" 2>/dev/null)
+	case "$podstatus" in
+	    Succeeded|Terminated)
+		return
+		;;
+	    Running)
+		# Need to produce periodic output to stderr to prevent oc exec connection from prematurely terminating
+		faildata="$("$OC" exec --stdin=false "$@" -- sh -c "while [[ ! -f '$sync_error_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; cat '$sync_error_file'" 2>/dev/null)"
+		if [[ -n "$faildata" ]] ; then
+		    "$OC" exec --stdin=false "$@" -- sh -c "rm -f '$sync_error_file'"
+		    echo "Run failed:" 1>&2
+		    echo "${faildata:-}" 1>&2
+		    killthemall "Run failed, exiting!"
+		fi
+		;;
+	    *)
+		sleep 1;
+		;;
+	esac
+    done
+}
+
 function _log_helper() {
+    local OPTIND=0
+    local OPTARG
+    local fail_helper=
+    while getopts 'e:' opt "$@" ; do
+	case "$opt" in
+	    e) fail_helper=$OPTARG ;;
+	    *)			   ;;
+	esac
+    done
+    shift $((OPTIND-1))
+    if [[ -n "${fail_helper:-}" ]] ; then
+	"$fail_helper" "$@" &
+    fi
     if [[ -n "${injected_errors[timeout]:-}" ]] ; then
 	echo "*** Injecting forced timeout error"
 	sleep infinity
@@ -1293,13 +1337,12 @@ function _get_logs_poll() {
 	    esac
 	done
 	# shellcheck disable=SC2086
-	local cleanup_command="; sleep 1; rm -f '$sync_flag_file'"
 	local mypid=$BASHPID
 	monitor_pods -- -l "${basename}-worker=$uuid" &
 	# shellcheck disable=SC2086
 	if supports_api -w "$requested_workload" supports_reporting ; then
 	    # Ensure that if there's a lot of output that we don't remove the sync file before it has all been flushed out
-	    run_logger -p "$mypid" -- _log_helper $pod &
+	    run_logger -p "$mypid" -- _log_helper -e _fail_helper -- $pod &
 	fi
 	trap 'kill $(jobs -p) 2>/dev/null 1>&2 && wait' USR2
 	wait
@@ -2503,6 +2546,8 @@ function create_container_sync() {
 $(indent 2 bootstrap_command_yaml sync.pl)
   - "-f"
   - "$sync_flag_file"
+  - "-e"
+  - "$sync_error_file"
   - "-t"
   - "$controller_timestamp_file"
   - "-d"

--- a/lib/clusterbuster/pod_files/clientlib.pl
+++ b/lib/clusterbuster/pod_files/clientlib.pl
@@ -259,28 +259,35 @@ sub do_sync($$;$) {
     return $answer;
 }
 
-sub run_cmd_to_stderr(@) {
+sub run_cmd(@) {
+    my ($answer);
     my (@cmd) = @_;
     timestamp("@cmd output");
     if (open(my $fh, "-|", @cmd)) {
 	while (<$fh>) {
-	    print STDERR "$cmd[0] $_";
+	    $answer .= "$cmd[0] $_";
 	}
 	close($fh)
     } else {
 	timestamp("Can't run $cmd[0]");
     }
+    return $answer;
 }
 
-sub finish($;$) {
-    my ($exit_at_end, $status) = @_;
-    run_cmd_to_stderr("lscpu");
-    run_cmd_to_stderr("dmesg");
-    if ($exit_at_end) {
-	if (defined $status && $status != 0) {
-	    print STDERR "FAIL!\n";
+sub finish($;$$$$$$$) {
+    my ($exit_at_end, $status, $namespace, $pod, $container, $synchost, $syncport, $pid) = @_;
+    my ($answer) = run_cmd("lscpu");
+    $answer .= run_cmd("dmesg");
+    timestamp($answer);
+    if (defined $status && $status != 0) {
+	print STDERR "FAIL!\n";
+	my ($buf) = sprintf("FAIL: %s/%s/%s%s\n%s", $namespace, $pod, $container, (defined $pid ? " pid: $pid" : ""), $answer);
+	do_sync($synchost, $syncport, $buf);
+	if ($exit_at_end) {
 	    POSIX::_exit($status);
 	}
+    }
+    if ($exit_at_end) {
 	timestamp("About to exit");
 	while (wait() > 0) {}
 	timestamp("Done waiting");

--- a/lib/clusterbuster/pod_files/clientlib.pl
+++ b/lib/clusterbuster/pod_files/clientlib.pl
@@ -272,11 +272,15 @@ sub run_cmd_to_stderr(@) {
     }
 }
 
-sub finish($) {
-    my ($exit_at_end) = @_;
+sub finish($;$) {
+    my ($exit_at_end, $status) = @_;
     run_cmd_to_stderr("lscpu");
     run_cmd_to_stderr("dmesg");
     if ($exit_at_end) {
+	if (defined $status && $status != 0) {
+	    print STDERR "FAIL!\n";
+	    POSIX::_exit($status);
+	}
 	timestamp("About to exit");
 	while (wait() > 0) {}
 	timestamp("Done waiting");

--- a/lib/clusterbuster/pod_files/cpusoaker.pl
+++ b/lib/clusterbuster/pod_files/cpusoaker.pl
@@ -75,13 +75,28 @@ sub runit() {
 	do_sync($loghost, $logport, $answer);
     }
 }
-$SIG{CHLD} = 'IGNORE';
+my (%pids) = ();
 if ($processes > 1) {
     for (my $i = 0; $i < $processes; $i++) {
-        if ((my $child = fork()) == 0) {
+	my $child;
+        if (($child = fork()) == 0) {
             runit();
             exit(0);
-        }
+        } else {
+	    $pids{$child} = 1;
+	}
+    }
+    while (%pids) {
+	my ($child) = wait();
+	if ($child == -1) {
+	    finish($exit_at_end);
+	} elsif (defined $pids{$child}) {
+	    if ($?) {
+		timestamp("Pid $child returned status $?!");
+		finish($exit_at_end, $?)
+	    }
+	    delete $pids{$child};
+	}
     }
 } else {
     runit();

--- a/lib/clusterbuster/pod_files/cpusoaker.pl
+++ b/lib/clusterbuster/pod_files/cpusoaker.pl
@@ -15,9 +15,9 @@ my ($start_time) = xtime();
 $SIG{TERM} = sub { kill 'KILL', -1; POSIX::_exit(0); };
 $basetime += $baseoffset;
 $crtime += $baseoffset;
+my ($pod) = hostname;
 
 sub runit() {
-    my ($pod) = hostname;
     initialize_timing($basetime, $crtime, $synchost, $syncport, "$namespace:$pod:$container:$$", $start_time);
     my ($iterations) = 0;
     my ($loops_per_iteration) = 10000;
@@ -76,30 +76,26 @@ sub runit() {
     }
 }
 my (%pids) = ();
-if ($processes > 1) {
-    for (my $i = 0; $i < $processes; $i++) {
-	my $child;
-        if (($child = fork()) == 0) {
-            runit();
-            exit(0);
-        } else {
-	    $pids{$child} = 1;
-	}
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
     }
-    while (%pids) {
-	my ($child) = wait();
-	if ($child == -1) {
-	    finish($exit_at_end);
-	} elsif (defined $pids{$child}) {
-	    if ($?) {
-		timestamp("Pid $child returned status $?!");
-		finish($exit_at_end, $?)
-	    }
-	    delete $pids{$child};
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-} else {
-    runit();
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/files.pl
+++ b/lib/clusterbuster/pod_files/files.pl
@@ -238,13 +238,28 @@ sub runit($) {
 }
 
 timestamp("Filebuster client starting");
-$SIG{CHLD} = 'IGNORE';
+my (%pids) = ();
 if ($processes > 1) {
     for (my $i = 0; $i < $processes; $i++) {
-        if ((my $child = fork()) == 0) {
+	my $child;
+        if (($child = fork()) == 0) {
             runit($i);
             exit(0);
-        }
+        } else {
+	    $pids{$child} = 1;
+	}
+    }
+    while (%pids) {
+	my ($child) = wait();
+	if ($child == -1) {
+	    finish($exit_at_end);
+	} elsif (defined $pids{$child}) {
+	    if ($?) {
+		timestamp("Pid $child returned status $?!");
+		finish($exit_at_end, $?)
+	    }
+	    delete $pids{$child};
+	}
     }
 } else {
     runit(0);

--- a/lib/clusterbuster/pod_files/fio.pl
+++ b/lib/clusterbuster/pod_files/fio.pl
@@ -214,14 +214,29 @@ sub runall() {
     removeRundir();
 }
 
+my (%pids) = ();
 if ($processes > 1) {
     for (my $i = 0; $i < $processes; $i++) {
-        if ((my $child = fork()) == 0) {
+	my $child;
+        if (($child = fork()) == 0) {
             runall();
             exit(0);
-        }
+        } else {
+	    $pids{$child} = 1;
+	}
     }
-    wait();
+    while (%pids) {
+	my ($child) = wait();
+	if ($child == -1) {
+	    finish($exit_at_end);
+	} elsif (defined $pids{$child}) {
+	    if ($?) {
+		timestamp("Pid $child returned status $?!");
+		finish($exit_at_end, $?)
+	    }
+	    delete $pids{$child};
+	}
+    }
 } else {
     runall();
 }

--- a/lib/clusterbuster/pod_files/fio.pl
+++ b/lib/clusterbuster/pod_files/fio.pl
@@ -63,7 +63,7 @@ sub prepare_data_file($) {
     timestamp("File created");
 }
 
-sub runit(;$) {
+sub runone(;$) {
     my ($jobfile) = @_;
     my ($firsttime) = 1;
     my ($avgcpu) = 0;
@@ -187,7 +187,7 @@ sub get_jobfiles($$$) {
     return @nfiles;
 }
 
-sub runall() {
+sub runit() {
     my ($localid) = $idname . ":$$";
     $localid =~ s/:/_/g;
     $localrundir = "$rundir/$localid";
@@ -206,39 +206,34 @@ sub runall() {
     my (@jobfiles) = get_jobfiles($jobfiles_dir, $tmp_jobfilesdir, $localid);
     if ($#jobfiles >= 0) {
 	foreach my $file (@jobfiles) {
-	    runit($file);
+	    runone($file);
 	}
     } else {
-        runit();
+        runone();
     }
     removeRundir();
 }
-
 my (%pids) = ();
-if ($processes > 1) {
-    for (my $i = 0; $i < $processes; $i++) {
-	my $child;
-        if (($child = fork()) == 0) {
-            runall();
-            exit(0);
-        } else {
-	    $pids{$child} = 1;
-	}
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
     }
-    while (%pids) {
-	my ($child) = wait();
-	if ($child == -1) {
-	    finish($exit_at_end);
-	} elsif (defined $pids{$child}) {
-	    if ($?) {
-		timestamp("Pid $child returned status $?!");
-		finish($exit_at_end, $?)
-	    }
-	    delete $pids{$child};
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-} else {
-    runall();
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/logger.pl
+++ b/lib/clusterbuster/pod_files/logger.pl
@@ -55,4 +55,8 @@ while ($processes-- > 0) {
 }
 
 while ((my $child = wait()) >= 0) {
+    if ($? > 0) {
+	timestamp("Logger failed!")
+	exit(1);
+    }
 }

--- a/lib/clusterbuster/pod_files/logger.pl
+++ b/lib/clusterbuster/pod_files/logger.pl
@@ -56,7 +56,7 @@ while ($processes-- > 0) {
 
 while ((my $child = wait()) >= 0) {
     if ($? > 0) {
-	timestamp("Logger failed!")
+	timestamp("Logger failed!");
 	exit(1);
     }
 }

--- a/lib/clusterbuster/pod_files/memory.pl
+++ b/lib/clusterbuster/pod_files/memory.pl
@@ -79,13 +79,28 @@ sub runit() {
 	do_sync($loghost, $logport, $answer);
     }
 }
-$SIG{CHLD} = 'IGNORE';
+my (%pids) = ();
 if ($processes > 1) {
     for (my $i = 0; $i < $processes; $i++) {
-        if ((my $child = fork()) == 0) {
+	my $child;
+        if (($child = fork()) == 0) {
             runit();
             exit(0);
-        }
+        } else {
+	    $pids{$child} = 1;
+	}
+    }
+    while (%pids) {
+	my ($child) = wait();
+	if ($child == -1) {
+	    finish($exit_at_end);
+	} elsif (defined $pids{$child}) {
+	    if ($?) {
+		timestamp("Pid $child returned status $?!");
+		finish($exit_at_end, $?)
+	    }
+	    delete $pids{$child};
+	}
     }
 } else {
     runit();

--- a/lib/clusterbuster/pod_files/memory.pl
+++ b/lib/clusterbuster/pod_files/memory.pl
@@ -10,14 +10,14 @@ use File::Basename;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
-our ($namespace, $container, $basetime, $baseoffset, $crtime, $exit_at_end, $synchost, $syncport, $loghost, $logport, $processes, $memory, $runtime) = @ARGV;
+my ($namespace, $container, $basetime, $baseoffset, $crtime, $exit_at_end, $synchost, $syncport, $loghost, $logport, $processes, $memory, $runtime) = @ARGV;
 my ($start_time) = xtime();
 $SIG{TERM} = sub { kill 'KILL', -1; POSIX::_exit(0); };
 $basetime += $baseoffset;
 $crtime += $baseoffset;
+my($pod) = hostname;
 
 sub runit() {
-    my ($pod) = hostname;
     initialize_timing($basetime, $crtime, $synchost, $syncport, "$namespace:$pod:$container:$$", $start_time);
     my ($mib_blk) = '';
     my ($kib_blk) = '';
@@ -80,30 +80,26 @@ sub runit() {
     }
 }
 my (%pids) = ();
-if ($processes > 1) {
-    for (my $i = 0; $i < $processes; $i++) {
-	my $child;
-        if (($child = fork()) == 0) {
-            runit();
-            exit(0);
-        } else {
-	    $pids{$child} = 1;
-	}
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
     }
-    while (%pids) {
-	my ($child) = wait();
-	if ($child == -1) {
-	    finish($exit_at_end);
-	} elsif (defined $pids{$child}) {
-	    if ($?) {
-		timestamp("Pid $child returned status $?!");
-		finish($exit_at_end, $?)
-	    }
-	    delete $pids{$child};
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-} else {
-    runit();
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/server.pl
+++ b/lib/clusterbuster/pod_files/server.pl
@@ -74,6 +74,9 @@ while ($expected_clients != 0) {
 timestamp("Waiting for all clients to exit:");
 while ((my $pid = wait()) >= 0) {
     timestamp("   $pid");
+    if ($? > 0) {
+	finish(1, $?);
+    }
 }
 timestamp("Done!");
 

--- a/lib/clusterbuster/pod_files/server.pl
+++ b/lib/clusterbuster/pod_files/server.pl
@@ -4,6 +4,7 @@ use POSIX;
 use strict;
 use Time::Piece;
 use Time::HiRes qw(gettimeofday usleep);
+use Sys::Hostname;
 use File::Basename;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
@@ -13,6 +14,8 @@ my ($namespace, $container, $basetime, $baseoffset, $crtime,
     $exit_at_end, $synchost, $syncport, $loghost, $logport, $listen_port,
     $msgSize, $ts, $expected_clients) = @ARGV;
 $basetime += $baseoffset;
+my ($pod) = hostname;
+my ($processes) = 1;
 
 timestamp("Clusterbuster server starting");
 my $sockaddr = "S n a4 x8";
@@ -26,58 +29,83 @@ my $mysockaddr = getsockname(SOCK);
 my ($junk, $port, $addr) = unpack($sockaddr, $mysockaddr);
 die "can't get port $port: $!\n" if ($port ne $listen_port);
 timestamp("Listening on port $listen_port");
-$SIG{CHLD} = 'IGNORE';
 
-print STDERR "Expect $expected_clients clients\n";
-while ($expected_clients != 0) {
-    accept(CLIENT, SOCK) || next;
-    if ((my $child = fork()) == 0) {
-	close(SOCK);
-	$SIG{TERM} = sub { close CLIENT; POSIX::_exit(0); };
-	my $peeraddr = getpeername(CLIENT);
-	my ($port, $addr) = sockaddr_in($peeraddr);
-	my $peerhost = gethostbyaddr($addr, AF_INET);
-	my $peeraddr = inet_ntoa($addr);
-	timestamp("Accepted connection from $peerhost ($peeraddr) on $port!");
-	my ($consec_empty) = 0;
-	my $buffer;
-	my $nread;
-	my $ntotal = 0;
-	my $nwrite;
-	while (1) {
-	    while ($ntotal < $msgSize && ($nread = sysread(CLIENT, $buffer, $msgSize, $ntotal)) > 0) {
-		$ntotal += $nread;
-		$consec_empty=0;
-	    }
-	    if ($nread < 0) {
-		die "Write failed: $!\n";
-	    }
-	    if ($ntotal == 0) {
-	        if ($consec_empty > 1) {
-		    timestamp("Exiting $port");
-		    exit(0);
+sub runit() {
+    print STDERR "Expect $expected_clients clients\n";
+    while ($expected_clients != 0) {
+	accept(CLIENT, SOCK) || next;
+	if ((my $child = fork()) == 0) {
+	    close(SOCK);
+	    $SIG{TERM} = sub { close CLIENT; POSIX::_exit(0); };
+	    my $peeraddr = getpeername(CLIENT);
+	    my ($port, $addr) = sockaddr_in($peeraddr);
+	    my $peerhost = gethostbyaddr($addr, AF_INET);
+	    my $peeraddr = inet_ntoa($addr);
+	    timestamp("Accepted connection from $peerhost ($peeraddr) on $port!");
+	    my ($consec_empty) = 0;
+	    my $buffer;
+	    my $nread;
+	    my $ntotal = 0;
+	    my $nwrite;
+	    while (1) {
+		while ($ntotal < $msgSize && ($nread = sysread(CLIENT, $buffer, $msgSize, $ntotal)) > 0) {
+		    $ntotal += $nread;
+		    $consec_empty=0;
 		}
-	        $consec_empty++;
+		if ($nread < 0) {
+		    die "Write failed: $!\n";
+		}
+		if ($ntotal == 0) {
+		    if ($consec_empty > 1) {
+			timestamp("Exiting $port");
+			exit(0);
+		    }
+		    $consec_empty++;
+		}
+		while ($ntotal > 0 && ($nwrite = syswrite(CLIENT, $buffer, $ntotal)) > 0) {
+		    $ntotal -= $nwrite;
+		}
+		if ($nwrite < 0) {
+		    die "Write failed: $!\n";
+		}
 	    }
-	    while ($ntotal > 0 && ($nwrite = syswrite(CLIENT, $buffer, $ntotal)) > 0) {
-		$ntotal -= $nwrite;
-	    }
-	    if ($nwrite < 0) {
-		die "Write failed: $!\n";
-	    }
+	} else {
+	    close(CLIENT);
+	    $expected_clients--;
 	}
+    }
+    timestamp("Waiting for all clients to exit:");
+    my ($status) = 0;
+    while ((my $pid = wait()) >= 0) {
+	timestamp("   $pid");
+	if ($? > 0) {
+	    $status = 1;
+	}
+    }
+    timestamp("Done!");
+    POSIX::exit($status);
+}
+my (%pids) = ();
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
     } else {
-	close(CLIENT);
-	$expected_clients--;
+	$pids{$child} = 1;
     }
 }
-timestamp("Waiting for all clients to exit:");
-while ((my $pid = wait()) >= 0) {
-    timestamp("   $pid");
-    if ($? > 0) {
-	finish(1, $?);
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
+	}
+	delete $pids{$child};
     }
 }
-timestamp("Done!");
 
-finish(1);
+finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/synctest.pl
+++ b/lib/clusterbuster/pod_files/synctest.pl
@@ -11,7 +11,7 @@ use File::Basename;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
-our ($namespace, $container, $basetime, $baseoffset, $crtime, $processes, $exit_at_end, $synchost, $syncport, $loghost, $logport, $sync_count, $sync_cluster_count, $sync_sleep) = @ARGV;
+my ($namespace, $container, $basetime, $baseoffset, $crtime, $processes, $exit_at_end, $synchost, $syncport, $loghost, $logport, $sync_count, $sync_cluster_count, $sync_sleep) = @ARGV;
 my ($start_time) = xtime();
 
 $SIG{TERM} = sub() { docleanup() };
@@ -48,30 +48,26 @@ sub runit() {
     }
 }
 my (%pids) = ();
-if ($processes > 1) {
-    for (my $i = 0; $i < $processes; $i++) {
-	my $child;
-        if (($child = fork()) == 0) {
-            runit();
-            exit(0);
-        } else {
-	    $pids{$child} = 1;
-	}
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
     }
-    while (%pids) {
-	my ($child) = wait();
-	if ($child == -1) {
-	    finish($exit_at_end);
-	} elsif (defined $pids{$child}) {
-	    if ($?) {
-		timestamp("Pid $child returned status $?!");
-		finish($exit_at_end, $?)
-	    }
-	    delete $pids{$child};
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-} else {
-    runit();
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/sysbench.pl
+++ b/lib/clusterbuster/pod_files/sysbench.pl
@@ -186,13 +186,28 @@ sub runit() {
 	do_sync($loghost, $logport, $answer);
     }
 }
-$SIG{CHLD} = 'IGNORE';
+my (%pids) = ();
 if ($processes > 1) {
     for (my $i = 0; $i < $processes; $i++) {
-        if ((my $child = fork()) == 0) {
+	my $child;
+        if (($child = fork()) == 0) {
             runit();
             exit(0);
-        }
+        } else {
+	    $pids{$child} = 1;
+	}
+    }
+    while (%pids) {
+	my ($child) = wait();
+	if ($child == -1) {
+	    finish($exit_at_end);
+	} elsif (defined $pids{$child}) {
+	    if ($?) {
+		timestamp("Pid $child returned status $?!");
+		finish($exit_at_end, $?)
+	    }
+	    delete $pids{$child};
+	}
     }
 } else {
     runit();

--- a/lib/clusterbuster/pod_files/sysbench.pl
+++ b/lib/clusterbuster/pod_files/sysbench.pl
@@ -11,7 +11,7 @@ use File::Basename;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
-our ($namespace, $container, $basetime, $baseoffset, $crtime, $exit_at_end, $synchost, $syncport, $loghost, $logport, $processes, $rundir, $runtime, $sysbench_generic_args, $sysbench_cmd, $sysbench_fileio_args, $sysbench_modes) = @ARGV;
+my ($namespace, $container, $basetime, $baseoffset, $crtime, $exit_at_end, $synchost, $syncport, $loghost, $logport, $processes, $rundir, $runtime, $sysbench_generic_args, $sysbench_cmd, $sysbench_fileio_args, $sysbench_modes) = @ARGV;
 my ($start_time) = xtime();
 
 $SIG{TERM} = sub() { docleanup() };
@@ -187,30 +187,26 @@ sub runit() {
     }
 }
 my (%pids) = ();
-if ($processes > 1) {
-    for (my $i = 0; $i < $processes; $i++) {
-	my $child;
-        if (($child = fork()) == 0) {
-            runit();
-            exit(0);
-        } else {
-	    $pids{$child} = 1;
-	}
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
     }
-    while (%pids) {
-	my ($child) = wait();
-	if ($child == -1) {
-	    finish($exit_at_end);
-	} elsif (defined $pids{$child}) {
-	    if ($?) {
-		timestamp("Pid $child returned status $?!");
-		finish($exit_at_end, $?)
-	    }
-	    delete $pids{$child};
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-} else {
-    runit();
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/uperf-client.pl
+++ b/lib/clusterbuster/pod_files/uperf-client.pl
@@ -15,6 +15,7 @@ my ($namespace, $container, $basetime, $baseoffset, $crtime,
     $srvhost, $connect_port, @tests) = @ARGV;
 my ($start_time, $data_start_time, $data_end_time, $elapsed_time, $end_time, $user, $sys, $cuser, $csys);
 $start_time = xtime();
+my ($processes) = 1;		# Not using multi-process here
 
 $SIG{TERM} = sub { POSIX::_exit(0); };
 $basetime += $baseoffset;
@@ -86,183 +87,208 @@ my (%results);
 my (%cases);
 my (@failed_cases) = ();
 
-my ($ucpu0, $scpu0) = cputime();
-foreach my $test (@tests) {
-    my ($test_type, $proto, $size, $nthr) = split(/, */, $test);
-    my ($base_test_name) = "${proto}-${test_type}-${size}B-${nthr}i";
-    my (%options) = (
-	'srvhost' => $srvhost,
-	'proto' => $proto,
-	'test_type' => $test_type,
-	'size' => $size,
-	'runtime' => $runtime + (2 * $ramp_time),
-	'nthr' => $nthr,
-	);
-    my ($test_template) = "$dir/uperf-${test_type}.xml";
-    my ($testfile) = "/tmp/fio-test.xml";
-    process_file($test_template, $testfile, %options);
-    my ($test_name) = sprintf('%04i-%s', $counter, $base_test_name);
-    my (%metadata) = (
-	'protocol' => $proto,
-	'test_type' => $test_type,
-	'message_size' => $size,
-	'thread_count' => $nthr,
-	'test_name' => $test_name
-	);
-    my ($failed) = 0;
-    do_sync($synchost, $syncport, "$namespace:$pod:$container:$$:$test_name");
-    timestamp("Running test $test_name");
-    system("cat /tmp/fio-test.xml 1>&2");
-    my ($job_start_time) = xtime();
-    if (! defined $data_start_time) {
-	$data_start_time = $job_start_time;
-    }
-    open(RUN, "-|", "uperf", "-f", "-P", "$connect_port", '-m', '/tmp/fio-test.xml', '-R', '-a', '-i', '1', '-Tf') || die "Can't run uperf: $!\n";
-    my ($start_time) = 0;
-    my ($last_time) = 0;
-    my ($last_nbytes) = 0;
-    my ($last_nops) = 0;
-    my ($ts_count) = 0;
-    my (%case);
-    my (@timeseries);
-    my (%threads);
-    my (%flowops);
-    my (%summary) = (
-	'write' => {},
-	'read' => {},
-	'total' => {},
-	);
-    my ($failure_message) = '';
-    while (<RUN>) {
-	chomp;
-	timestamp($_);
-	if (/^timestamp_ms:([[:digit:].]+) +name:([[:alnum:]]+) +nr_bytes:([[:digit:]]+) +nr_ops:([[:digit:]]+)/) {
-	    my ($ts) = $1 / 1000.0;
-	    my ($name) = $2;
-	    my ($nbytes) = $3 + 0.0;
-	    my ($nops) = $4 + 0.0;
-	    # We only care about Txn2 and threads; the other transactions are start
-	    # and finish, and we want to ignore those
-	    if ($name eq 'Txn2') {
-		if ($start_time == 0) {
-		    $start_time = $ts;
-		    $last_time = $ts;
-		} else {
+sub runit() {
+    my ($ucpu0, $scpu0) = cputime();
+    foreach my $test (@tests) {
+	my ($test_type, $proto, $size, $nthr) = split(/, */, $test);
+	my ($base_test_name) = "${proto}-${test_type}-${size}B-${nthr}i";
+	my (%options) = (
+	    'srvhost' => $srvhost,
+	    'proto' => $proto,
+	    'test_type' => $test_type,
+	    'size' => $size,
+	    'runtime' => $runtime + (2 * $ramp_time),
+	    'nthr' => $nthr,
+	    );
+	my ($test_template) = "$dir/uperf-${test_type}.xml";
+	my ($testfile) = "/tmp/fio-test.xml";
+	process_file($test_template, $testfile, %options);
+	my ($test_name) = sprintf('%04i-%s', $counter, $base_test_name);
+	my (%metadata) = (
+	    'protocol' => $proto,
+	    'test_type' => $test_type,
+	    'message_size' => $size,
+	    'thread_count' => $nthr,
+	    'test_name' => $test_name
+	    );
+	my ($failed) = 0;
+	do_sync($synchost, $syncport, "$namespace:$pod:$container:$$:$test_name");
+	timestamp("Running test $test_name");
+	system("cat /tmp/fio-test.xml 1>&2");
+	my ($job_start_time) = xtime();
+	if (! defined $data_start_time) {
+	    $data_start_time = $job_start_time;
+	}
+	open(RUN, "-|", "uperf", "-f", "-P", "$connect_port", '-m', '/tmp/fio-test.xml', '-R', '-a', '-i', '1', '-Tf') || die "Can't run uperf: $!\n";
+	my ($start_time) = 0;
+	my ($last_time) = 0;
+	my ($last_nbytes) = 0;
+	my ($last_nops) = 0;
+	my ($ts_count) = 0;
+	my (%case);
+	my (@timeseries);
+	my (%threads);
+	my (%flowops);
+	my (%summary) = (
+	    'write' => {},
+	    'read' => {},
+	    'total' => {},
+	    );
+	my ($failure_message) = '';
+	while (<RUN>) {
+	    chomp;
+	    timestamp($_);
+	    if (/^timestamp_ms:([[:digit:].]+) +name:([[:alnum:]]+) +nr_bytes:([[:digit:]]+) +nr_ops:([[:digit:]]+)/) {
+		my ($ts) = $1 / 1000.0;
+		my ($name) = $2;
+		my ($nbytes) = $3 + 0.0;
+		my ($nops) = $4 + 0.0;
+		# We only care about Txn2 and threads; the other transactions are start
+		# and finish, and we want to ignore those
+		if ($name eq 'Txn2') {
+		    if ($start_time == 0) {
+			$start_time = $ts;
+			$last_time = $ts;
+		    } else {
+			my (%row) = (
+			    'time' => $ts - $start_time,
+			    'timedelta' => $ts - $last_time,
+			    'bytes' => $nbytes - $last_nbytes,
+			    'nops' => $nops - $last_nops,
+			    );
+			push @timeseries, \%row;
+			$last_time = $ts;
+			$last_nbytes = $nbytes;
+			$last_nops = $nops;
+		    }
+		} elsif ($name =~ /^Thr([[:digit:]])+/) {
 		    my (%row) = (
 			'time' => $ts - $start_time,
-			'timedelta' => $ts - $last_time,
-			'bytes' => $nbytes - $last_nbytes,
-			'nops' => $nops - $last_nops,
+			'bytes' => $nbytes,
+			'nops' => $nops,
 			);
-		    push @timeseries, \%row;
-		    $last_time = $ts;
-		    $last_nbytes = $nbytes;
-		    $last_nops = $nops;
+		    $threads{$name} = %row;
 		}
-	    } elsif ($name =~ /^Thr([[:digit:]])+/) {
-		my (%row) = (
-		    'time' => $ts - $start_time,
-		    'bytes' => $nbytes,
-		    'nops' => $nops,
-		    );
-		$threads{$name} = %row;
+	    } elsif (/^(Txn1|write|read)[ \t]/) {
+		my ($op, $count, $avg, $cpu, $max, $min) = split;
+		if ($op eq 'Txn1') {
+		    $op = 'total';
+		}
+		$summary{$op}{'time_avg'} = compute_seconds($avg);
+		$summary{$op}{'time_max'} = compute_seconds($max);
+		$summary{$op}{'time_min'} = compute_seconds($min);
+	    } elsif (/^[*][*] Error/) {
+		$failure_message = $_;
+		$failed = 1;
+		timestamp("Test case $test_name failed!");
+		push @failed_cases, $test_name;
+	    } elsif (/^[*]/) {
+		timestamp($_);
+	    } elsif (/WARNING: Errors/ && ! $failed) {
+		$failure_message = $_;
+		$failed = 1;
+		timestamp("Test case $test_name failed!");
+		push @failed_cases, $test_name;
 	    }
-	} elsif (/^(Txn1|write|read)[ \t]/) {
-	    my ($op, $count, $avg, $cpu, $max, $min) = split;
-	    if ($op eq 'Txn1') {
-		$op = 'total';
+	}
+	close(RUN);
+	$data_end_time = xtime();
+	$summary{'raw_elapsed_time'} = $last_time - $start_time;
+	$summary{'raw_nbytes'} = $last_nbytes;
+	$summary{'raw_nops'} = $last_nops;
+	if ($summary{'raw_elapsed_time'} > 0) {
+	    $summary{'raw_avg_ops_sec'} = $summary{'raw_nops'} / $summary{'raw_elapsed_time'};
+	    $summary{'raw_avg_bytes_sec'} = $summary{'raw_nbytes'} / $summary{'raw_elapsed_time'};
+	}
+	$summary{'nbytes'} = 0;
+	$summary{'nops'} = 0;
+	$summary{'elapsed_time'} = 0;
+	$summary{'avg_bytes_sec'} = 0;
+	$summary{'avg_ops_sec'} = 0;
+	my ($ops_sec_sum) = 0;
+	my ($ops_sec_sq_sum) = 0;
+	my ($bytes_sec_sum) = 0;
+	my ($bytes_sec_sq_sum) = 0;
+	my ($stdev_counter) = 0;
+	map {
+	    $summary{'nbytes'} += $$_{'bytes'};
+	    $summary{'nops'} += $$_{'nops'};
+	    $summary{'elapsed_time'} += $$_{'timedelta'};
+	    my ($ops_sec) = $$_{'nops'} / $$_{'timedelta'};
+	    my ($bytes_sec) = $$_{'bytes'} / $$_{'timedelta'};
+	    $ops_sec_sum += $ops_sec;
+	    $ops_sec_sq_sum += $ops_sec * $ops_sec;
+	    $bytes_sec_sum += $bytes_sec;
+	    $bytes_sec_sq_sum += $bytes_sec * $bytes_sec;
+	    $stdev_counter++;
+	} grep { ($summary{'raw_elapsed_time'} < 10 ||
+		  ($$_{'time'} >= $ramp_time &&
+		   $$_{'time'} < $summary{'raw_elapsed_time'} - $ramp_time)) } @timeseries;
+	if ($summary{'elapsed_time'} > 0) {
+	    $summary{'avg_bytes_sec'} = $summary{'nbytes'} / $summary{'elapsed_time'};
+	    $summary{'avg_ops_sec'} = $summary{'nops'} / $summary{'elapsed_time'};
+	    $summary{'bytes_sec_sq_sum'} = $bytes_sec_sq_sum;
+	    $summary{'bytes_sec_sum'} = $bytes_sec_sum;
+	    $summary{'ops_sec_sq_sum'} = $ops_sec_sq_sum;
+	    $summary{'ops_sec_sum'} = $ops_sec_sum;
+	    if ($stdev_counter >= 2) {
+		$summary{'stdev_bytes_sec'} = (($bytes_sec_sq_sum / $stdev_counter) - ($summary{'avg_bytes_sec'} ** 2)) ** 0.5;
+		$summary{'stdev_ops_sec'} = (($ops_sec_sq_sum / $stdev_counter) - ($summary{'avg_ops_sec'} ** 2)) ** 0.5;
+	    } else {
+		$summary{'stdev_bytes_sec'} = 0;
+		$summary{'stdev_ops_sec'} = 0;
 	    }
-	    $summary{$op}{'time_avg'} = compute_seconds($avg);
-	    $summary{$op}{'time_max'} = compute_seconds($max);
-	    $summary{$op}{'time_min'} = compute_seconds($min);
-	} elsif (/^[*][*] Error/) {
-	    $failure_message = $_;
-	    $failed = 1;
-	    timestamp("Test case $test_name failed!");
-	    push @failed_cases, $test_name;
-	} elsif (/^[*]/) {
-	    timestamp($_);
-	} elsif (/WARNING: Errors/ && ! $failed) {
-	    $failure_message = $_;
-	    $failed = 1;
-	    timestamp("Test case $test_name failed!");
-	    push @failed_cases, $test_name;
 	}
+	$summary{'job_start'} = $job_start_time;
+	$summary{'job_end'} = $data_end_time;
+	$case{'status'}{'condition'} = $failed ? 'FAIL' : 'PASS';
+	$case{'status'}{'message'} = $failure_message;
+	$case{'metadata'} = \%metadata;
+	$case{'summary'} = \%summary;
+	$case{'timeseries'} = \@timeseries;
+	$elapsed_time += $summary{'elapsed_time'};
+	$counter++;
+	$cases{$test_name} = \%case;
     }
-    close(RUN);
-    $data_end_time = xtime();
-    $summary{'raw_elapsed_time'} = $last_time - $start_time;
-    $summary{'raw_nbytes'} = $last_nbytes;
-    $summary{'raw_nops'} = $last_nops;
-    if ($summary{'raw_elapsed_time'} > 0) {
-	$summary{'raw_avg_ops_sec'} = $summary{'raw_nops'} / $summary{'raw_elapsed_time'};
-	$summary{'raw_avg_bytes_sec'} = $summary{'raw_nbytes'} / $summary{'raw_elapsed_time'};
+    $results{'results'} = \%cases;
+    $results{'failed'} = \@failed_cases;
+
+    my ($ucpu1, $scpu1) = cputime();
+    $ucpu1 -= $ucpu0;
+    $scpu1 -= $scpu0;
+
+    my ($results) = print_json_report($namespace, $pod, $container, $$, $data_start_time,
+				      $data_end_time, $elapsed_time, $ucpu1, $scpu1, \%results);
+    timestamp("Done");
+    if ($syncport) {
+	do_sync($synchost, $syncport, $results);
     }
-    $summary{'nbytes'} = 0;
-    $summary{'nops'} = 0;
-    $summary{'elapsed_time'} = 0;
-    $summary{'avg_bytes_sec'} = 0;
-    $summary{'avg_ops_sec'} = 0;
-    my ($ops_sec_sum) = 0;
-    my ($ops_sec_sq_sum) = 0;
-    my ($bytes_sec_sum) = 0;
-    my ($bytes_sec_sq_sum) = 0;
-    my ($stdev_counter) = 0;
-    map {
-	$summary{'nbytes'} += $$_{'bytes'};
-	$summary{'nops'} += $$_{'nops'};
-	$summary{'elapsed_time'} += $$_{'timedelta'};
-	my ($ops_sec) = $$_{'nops'} / $$_{'timedelta'};
-	my ($bytes_sec) = $$_{'bytes'} / $$_{'timedelta'};
-	$ops_sec_sum += $ops_sec;
-	$ops_sec_sq_sum += $ops_sec * $ops_sec;
-	$bytes_sec_sum += $bytes_sec;
-	$bytes_sec_sq_sum += $bytes_sec * $bytes_sec;
-	$stdev_counter++;
-    } grep { ($summary{'raw_elapsed_time'} < 10 ||
-	      ($$_{'time'} >= $ramp_time &&
-	       $$_{'time'} < $summary{'raw_elapsed_time'} - $ramp_time)) } @timeseries;
-    if ($summary{'elapsed_time'} > 0) {
-	$summary{'avg_bytes_sec'} = $summary{'nbytes'} / $summary{'elapsed_time'};
-	$summary{'avg_ops_sec'} = $summary{'nops'} / $summary{'elapsed_time'};
-	$summary{'bytes_sec_sq_sum'} = $bytes_sec_sq_sum;
-	$summary{'bytes_sec_sum'} = $bytes_sec_sum;
-	$summary{'ops_sec_sq_sum'} = $ops_sec_sq_sum;
-	$summary{'ops_sec_sum'} = $ops_sec_sum;
-	if ($stdev_counter >= 2) {
-	    $summary{'stdev_bytes_sec'} = (($bytes_sec_sq_sum / $stdev_counter) - ($summary{'avg_bytes_sec'} ** 2)) ** 0.5;
-	    $summary{'stdev_ops_sec'} = (($ops_sec_sq_sum / $stdev_counter) - ($summary{'avg_ops_sec'} ** 2)) ** 0.5;
-	} else {
-	    $summary{'stdev_bytes_sec'} = 0;
-	    $summary{'stdev_ops_sec'} = 0;
+    if ($logport > 0) {
+	do_sync($loghost, $logport, $results);
+    }
+}
+
+my (%pids) = ();
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
+    }
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
 	}
+	delete $pids{$child};
     }
-    $summary{'job_start'} = $job_start_time;
-    $summary{'job_end'} = $data_end_time;
-    $case{'status'}{'condition'} = $failed ? 'FAIL' : 'PASS';
-    $case{'status'}{'message'} = $failure_message;
-    $case{'metadata'} = \%metadata;
-    $case{'summary'} = \%summary;
-    $case{'timeseries'} = \@timeseries;
-    $elapsed_time += $summary{'elapsed_time'};
-    $counter++;
-    $cases{$test_name} = \%case;
-}
-$results{'results'} = \%cases;
-$results{'failed'} = \@failed_cases;
-
-my ($ucpu1, $scpu1) = cputime();
-$ucpu1 -= $ucpu0;
-$scpu1 -= $scpu0;
-
-my ($results) = print_json_report($namespace, $pod, $container, $$, $data_start_time,
-				  $data_end_time, $elapsed_time, $ucpu1, $scpu1, \%results);
-timestamp("Done");
-if ($syncport) {
-    do_sync($synchost, $syncport, $results);
-}
-if ($logport > 0) {
-    do_sync($loghost, $logport, $results);
 }
 
 finish($exit_at_end);

--- a/lib/clusterbuster/pod_files/uperf-server.pl
+++ b/lib/clusterbuster/pod_files/uperf-server.pl
@@ -4,6 +4,7 @@ use POSIX;
 use strict;
 use Time::Piece;
 use Time::HiRes qw(gettimeofday usleep);
+use Sys::Hostname;
 use File::Basename;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
@@ -12,10 +13,36 @@ $SIG{TERM} = sub { POSIX::_exit(0); };
 my ($namespace, $container, $basetime, $baseoffset, $crtime,
     $exit_at_end, $synchost, $syncport, $loghost, $logport, $listen_port) = @ARGV;
 $basetime += $baseoffset;
-$SIG{CHLD} = 'IGNORE';
+my ($pod) = hostname;
+my ($processes) = 1;
 
-timestamp("Starting uperf server on port $listen_port");
-system("uperf", "-s", "-v", "-P", "$listen_port");
-timestamp("Done!");
+sub runit() {
+    timestamp("Starting uperf server on port $listen_port");
+    system("uperf", "-s", "-v", "-P", "$listen_port");
+    timestamp("Done!");
+}
 
-finish(1);
+my (%pids) = ();
+for (my $i = 0; $i < $processes; $i++) {
+    my $child;
+    if (($child = fork()) == 0) {
+	runit();
+	exit(0);
+    } else {
+	$pids{$child} = 1;
+    }
+}
+while (%pids) {
+    my ($child) = wait();
+    if ($child == -1) {
+	finish($exit_at_end);
+    } elsif (defined $pids{$child}) {
+	if ($?) {
+	    timestamp("Pid $child returned status $?!");
+	    finish($exit_at_end, $?, $namespace, $pod, $container, $synchost, $syncport, $child);
+	}
+	delete $pids{$child};
+    }
+}
+
+finish($exit_at_end);


### PR DESCRIPTION
If one process in a pod fails, the entire pod should be failed immediately rather than waiting forever (or until the job times out).
