### PR TITLE
Improve efficiency of pod monitoring

### DIFF
--- a/CI/run-kata-perf-suite
+++ b/CI/run-kata-perf-suite
@@ -601,7 +601,7 @@ function xruntimeclass() {
 }
 
 function doit() {
-    echo "$*"
+    echo "${@@Q}"
     if ((! debugonly)) ; then
 	exec "$@" &
 	job_pid=$!

--- a/clusterbuster
+++ b/clusterbuster
@@ -694,7 +694,7 @@ function process_option() {
 	    esac
 	    ;;
 	# Object creation
-	objspercall)		    objs_per_call=$optvalue			;;
+	obj*spercall)		    objs_per_call=$optvalue			;;
 	parallel)		    parallel=$optvalue				;;
 	sleep)			    sleeptime=$optvalue				;;
 	podprefix)		    pod_prefix=${optvalue:+$optvalue-}		;;
@@ -703,10 +703,10 @@ function process_option() {
 	parallelsecrets)	    parallel_secrets=$optvalue			;;
 	parallelnamespaces)	    parallel_namespaces=$optvalue		;;
 	paralleldeployments)	    parallel_deployments=$optvalue		;;
-	objspercallconfigmaps)	    objs_per_call_configmaps=$optvalue		;;
-	objspercallsecrets)	    objs_per_call_secrets=$optvalue		;;
-	objspercallnamespaces)	    objs_per_call_namespaces=$optvalue		;;
-	objspercalldeployments)	    objs_per_call_deployments=$optvalue		;;
+	obj*spercallconfigmaps)	    objs_per_call_configmaps=$optvalue		;;
+	obj*spercallsecrets)	    objs_per_call_secrets=$optvalue		;;
+	obj*spercallnamespaces)	    objs_per_call_namespaces=$optvalue		;;
+	obj*spercalldeployments)    objs_per_call_deployments=$optvalue		;;
 	sleepbetweenconfigmaps)	    sleep_between_configmaps=$optvalue		;;
 	sleepbetweensecrets)	    sleep_between_secrets=$optvalue		;;
 	sleepbetweennamespaces)	    sleep_between_namespaces=$optvalue		;;
@@ -1094,114 +1094,115 @@ function timestamp() {
     done
 }
 
-function monitor_pods() {
-    exec 0</dev/null 1>/dev/null
-    local arg
-    local -i timeout=-1
-    local -i ppid=0
-    local OPTIND=0
-    while getopts "t:" arg "$@" ; do
-	case "$arg" in
-	    t) timeout="$OPTARG" ;;
-	    *)                   ;;
-	esac
-    done
-    shift $((OPTIND - 1))
+function run_status_monitor() {
+    (while : ; do sleep 1; printf '++Mark++ ++Mark+ %(%s)T%s' -1 $'\n'; done &); oc get pod "$@" -w -o jsonpath='{.metadata.namespace} {.metadata.name} {.status.phase}{"\n"}'
+}
+
+function _monitor_pods() {
     if ((timeout > 0)) ; then
 	timeout=$(($(date +%s) + timeout))
     fi
     local pods_pending=''
-    local -i pods_pending_retry=12
-    local -i pods_unchanged_countdown=$pods_pending_retry
+    local -i pod_progress_timeout=0
     if [[ -n "${injected_errors[timeout]:-}" ]] ; then
 	warn "*** Injecting forced timeout error"
     fi
-    while : ; do
-	# Stop work as soon as we know we're done.
-	if [[ -z "${injected_errors[timeout]:-}" && -n "$cb_tempdir" && -f "$cb_tempdir/___run_complete" ]] ; then
-	    return 0
-	fi
-	# shellcheck disable=2034
-	local -a pending_pods=()
-	local -i running_pod_count=0
-	local -i finished_pod_count=0
-	local -i other_pod_count=0
-	while read -r namespace name rdy status rest ; do
-	    if [[ -z "${injected_errors[timeout]:-}" && -n "$cb_tempdir" && -f "$cb_tempdir/___run_complete" ]] ; then
-		# Don't exit out of this, which will leave the oc get pods process around
-		continue
+    # shellcheck disable=2034
+    local -i running_pod_count=0
+    local -i finished_pod_count=0
+    local -i other_pod_count=0
+    local -A pod_status=()
+    local -A running_pods=()
+    local -A starting_pods=()
+    local pod
+    local name
+    local namespace
+    local status
+    local lstatus
+    if [[ -n "${injected_errors[pending]:-}" ]] ; then
+	warn "*** Injecting pending error"
+	starting_pods["TEST/TEST"]=1
+    fi
+    while read -r namespace name status ; do
+	if [[ -n "${cb_tempdir:-}" && -f "$cb_tempdir/___run_complete" ]] ; then
+	    if [[ -z "${injected_errors[timeout]:-}" ]] ; then
+		return 0
+	    else
+		sleep infinity
 	    fi
-	    case "${status,,}" in
+	fi
+	if [[ $namespace != ++Mark++ ]] ; then
+	    # This definitely shouldn't happen, but being defensive doesn't hurt.
+	    if [[ -z "$status" || -z "$namespace" || -z "$name" ]] ; then continue; fi
+	    pod="${namespace,,}/${name,,}"
+	    lstatus="${status,,}"
+	    # No guarantee that we won't get a repeated status
+	    if [[ $lstatus = "${pod_status[$name]:-}" ]] ; then continue; fi
+	    # Ignore status of any leftover pods from earlier runs
+	    if [[ ($lstatus = completed || $lstatus = succeeded || $lstatus = 'terminat'* || $lstatus = error || $lstatus = failed) && -z "${pod_status[$pod]:-}" ]] ; then continue; fi
+	    pod_status["$pod"]=$lstatus
+	    unset starting_pods["$pod"]
+	    unset running_pods["$pod"]
+	    case "$lstatus" in
 		error|failed)
 		    echo "Pod -n $namespace $name $status!" 1>&2
 		    echo "Tail end of logs:" 1>&2
+		    # TODO: Need to get logs from each container
 		    oc logs -n "$namespace" "$name" |tail -20 1>&2
-		    killthemall
+		    killthemall "Pod -n $namespace $name failed"
+		    return 1
 		    ;;
 		pending|containercreating)
-		    other_pod_count=$((other_pod_count+1))
-		    pending_pods+=("$namespace/$name")
+		    starting_pods["$namespace/$name"]=1
 		    ;;
 		running)
-		    running_pod_count=$((running_pod_count+1))
+		    other_pod_count=$((other_pod_count-1))
+		    running_pods["$namespace/$name"]=1
 		    ;;
-		completed|terminated)
-		    if supports_api -w "$requested_workload" supports_reporting ; then
-			if ! __OC exec --stdin=false -n "${basename}-sync" "$(mkpodname "${basename}-sync")" -- test -f /tmp/clusterbuster-finished ; then
-			    echo "Sync pod exited prematurely!" 1>&2
-			    echo "Tail end of logs:" 1>&2
-			    oc logs -n "${basename}-sync" "${basename}-sync" |tail -20 1>&2
-			    killthemall "Unexpected termination of sync pod"
-			fi
-		    fi
+		completed|terminat*|succeeded)
+		    unset pod_status["$pod"]
+		    other_pod_count=$((other_pod_count-1))
 		    finished_pod_count=$((finished_pod_count+1))
 		    ;;
 		*)
 		    other_pod_count=$((other_pod_count+1))
 		    ;;
 	    esac
-	done <<< "$(__OC get pods -A --no-headers "$@" 2>/dev/null)"
-	if [[ -z "${injected_errors[timeout]:-}" && -n "$cb_tempdir" && -f "$cb_tempdir/___run_complete" ]] ; then
-	    return 0
-	fi
-	if [[ -z "${injected_errors[timeout]:-}" ]] && ! supports_api -w "$requested_workload" supports_reporting ; then
-	    if (( running_pod_count + finished_pod_count > 0 && other_pod_count == 0 )) ; then
-		sleep "$workload_run_time"
-		return
-	    fi
-	fi
-
-	if [[ -n "${injected_errors[pending]:-}" ]] ; then
-	    warn "*** Injecting pending error"
-	    pending_pods+=("TEST/TEST")
-	fi
-
-	if [[ -n "${pending_pods[*]}" ]] ; then
-	    pods_now_pending=$(IFS=$'\n'; echo "${pending_pods[*]}" | sort)
-	    if [[ "$pods_now_pending" != "$pods_pending" ]] ; then
-		pods_unchanged_countdown=$pods_pending_retry
-		pods_pending="$pods_now_pending"
-	    else
-		if ((pods_unchanged_countdown <= 0)) ; then
-		    killthemall "No progress with pods after 10 retries, ${#pending_pods[@]} pods still pending."
+	else
+	    # Timestamp
+	    local timestamp=$status
+	    # If 
+	    if [[ -z "${injected_errors[timeout]:-}" ]] && ! supports_api -w "$requested_workload" supports_reporting ; then
+		if (( ${#running_pods[@]} + finished_pod_count > 0 && other_pod_count == 0 )) ; then
+		    sleep "$workload_run_time"
+		    return
 		fi
-		local times=times
-		if ((pods_unchanged_countdown == 1)) ; then times='time' ; fi
-		echo "${#pending_pods[@]} pods pending (will retry $pods_unchanged_countdown $times)" | echo_if_desired 1>&2
-		pods_unchanged_countdown=$((pods_unchanged_countdown-1))
+	    fi
+
+	    if [[ -n "${starting_pods[*]}" ]] ; then
+		pods_now_pending=$(IFS=$'\n'; echo "${!starting_pods[*]}" | sort)
+		if [[ "$pods_now_pending" != "$pods_pending" ]] ; then
+		    pod_progress_timeout=$((timestamp+60))
+		    pods_pending="$pods_now_pending"
+		else
+		    if ((timestamp > pod_progress_timeout)) ; then
+			killthemall "No progress with pods after 1 minute, ${#starting_pods[@]} pods still pending."
+		    fi
+		    local seconds=seconds
+		    if ((pod_progress_timeout-timestamp == 1)) ; then seconds='second' ; fi
+		    echo "${#starting_pods[@]} pods pending (will retry $((pod_progress_timeout-timestamp)) $seconds)" | echo_if_desired 1>&2
+		fi
+	    fi
+	    if ((timeout > 0 && timestamp > timeout)) ; then
+		killthemall "Monitor pods timeout!"
 	    fi
 	fi
-	if ((timeout > 0 && $(date +%s) > timeout)) ; then
-	    killthemall "Monitor pods timeout!"
-	fi
-	local -i i
-	for i in {1..5} ; do
-	    if [[ -z "${injected_errors[timeout]:-}" && -n "$cb_tempdir" && -f "$cb_tempdir/___run_complete" ]] ; then
-		return 0
-	    fi
-	    sleep 1
-	done
     done
+}
+
+function monitor_pods() {
+    exec 0</dev/null 1>/dev/null
+    run_status_monitor "$@" | _monitor_pods "$timeout"
 }
 
 function run_logger() {
@@ -1277,7 +1278,7 @@ function _log_helper() {
 	sleep 5
     done
     # Tell the pod monitor to stop.
-    if [[ -n "$cb_tempdir" ]] ; then
+    if [[ -n "${cb_tempdir:-}" ]] ; then
 	touch "$cb_tempdir/___run_complete"
     fi
     "$OC" exec --stdin=false "$@" -- sh -c "rm -f '$sync_flag_file'" || killthemall "Can't terminate sync"
@@ -1322,7 +1323,7 @@ function _get_logs_poll() {
 	done
 	# shellcheck disable=SC2086
 	local mypid=$BASHPID
-	monitor_pods -- -l "${basename}-worker=$uuid" &
+	monitor_pods -A -l "${basename}-worker=$uuid" &
 	# shellcheck disable=SC2086
 	if supports_api -w "$requested_workload" supports_reporting ; then
 	    # Ensure that if there's a lot of output that we don't remove the sync file before it has all been flushed out
@@ -1605,7 +1606,8 @@ function indent() {
 }
 
 function mkpodname() {
-    local podname="${pod_prefix}$(IFS=-; echo "$*")"
+    local podname
+    podname="${pod_prefix}$(IFS=-; echo "$*")"
     echo "${podname//_/-}"
 }
 
@@ -1715,7 +1717,8 @@ function create_standard_containers() {
     local -i container
     local sync_service=
     local sync_port_num=
-    local yaml_args="$(mk_yaml_args)"
+    local yaml_args
+    yaml_args="$(mk_yaml_args)"
     IFS=: read -r sync_service sync_port_num <<< "$(get_sync)"
     for container in $(seq 0 $((containers - 1))) ; do
 	cat <<EOF
@@ -2086,15 +2089,14 @@ function _really_create_objects() {
 	    echo "$accumulateddata" 1>&2
 	    killthemall "Failed to create objects"
 	}
-	accumulateddata=
-	objs_item_count=0
     fi
 }
 
 function really_create_objects() {
-    _really_create_objects "$@" | timestamp 1>&2
+    _really_create_objects | timestamp 1>&2
     accumulateddata=
     objs_item_count=0
+    return "${PIPESTATUS[0]}"
 }
 
 function create_object() {

--- a/clusterbuster
+++ b/clusterbuster
@@ -832,17 +832,17 @@ function generate_workload_metadata() {
 ################################################################
 
 function __OC() {
+    if [[ -n "$debug" && $doit -ne 0 ]] ; then
+	echo "$OC" "${@@Q}" | timestamp 1>&2
+    fi
     if ((! doit)) ; then
-	echo "$OC" "$@" 1>&2
+	echo "$OC" "${@@Q}" 1>&2
     elif [[ $1 = exec || $1 = rsh ]] ; then
 	# Capture error output
 	(set -o pipefail; "$OC" "$@" 2>&1 1>&3 |sed -e "s/^/${*//\//\\/}: /" |timestamp 1>&2) 3>&1
     elif [[ $1 = describe || $1 = get || $1 = status || $1 = logs ]] ; then
 	"$OC" "$@"
     elif ((report_object_creation)) ; then
-	if [[ -n "$debug" ]] ; then
-	    echo "$OC" "$@" 1>&2
-	fi
 	"$OC" "$@" 2>&1
     else
 	"$OC" "$@" 2>&1 |grep -v -E '(^No resources found|deleted|created|labeled|condition met)$'
@@ -1188,9 +1188,13 @@ function _monitor_pods() {
 		    if ((timestamp > pod_progress_timeout)) ; then
 			killthemall "No progress with pods after 1 minute, ${#starting_pods[@]} pods still pending."
 		    fi
-		    local seconds=seconds
-		    if ((pod_progress_timeout-timestamp == 1)) ; then seconds='second' ; fi
-		    echo "${#starting_pods[@]} pods pending (will retry $((pod_progress_timeout-timestamp)) $seconds)" | echo_if_desired 1>&2
+		    if ((pod_progress_timeout-timestamp <= 30)) ; then
+			local p_seconds=seconds
+			local p_pods=pods
+			if ((pod_progress_timeout-timestamp == 1)) ; then p_seconds=second; fi
+			if ((${#starting_pods[@]} == 1)) ; then p_pods=pod; fi
+			echo "${#starting_pods[@]} $p_pods pending (will retry $((pod_progress_timeout-timestamp)) $p_seconds)" | echo_if_desired 1>&2
+		    fi
 		fi
 	    fi
 	    if ((timeout > 0 && timestamp > timeout)) ; then


### PR DESCRIPTION
- Use oc/kubectl get -w to monitor pods for improved efficiency.
- Check for changes more frequently (every second vs. every 5 seconds)
  because it doesn't put any more load on the apiserver.