### PR TITLE
Check exit status of worker processes

### DIFF
--- a/lib/clusterbuster/pod_files/fio.pl
+++ b/lib/clusterbuster/pod_files/fio.pl
@@ -114,7 +114,10 @@ sub runone(;$) {
 				timestamp($_);
 				$answer0 .= "$_";
 			    }
-			    close(RUN);
+			    if (!close(RUN)) {
+				timestamp("fio failed: $! $?");
+				exit(1);
+			    }
 			    timestamp("Done job $jobfile $jobname");
 			    my ($jtime1) = xtime();
 			    my ($jucpu1, $jscpu1) = cputime();


### PR DESCRIPTION
Workloads that run outside workers (currently fio and uperf) should check the status when their pipes are closed.

Tested selectively with fio and uperf runs.