### PR TITLE
Miscellaneous fixes

### DIFF
--- a/CI/run-kata-perf-suite
+++ b/CI/run-kata-perf-suite
@@ -58,7 +58,6 @@ declare -i use_python_venv=1
 declare python_venv=
 declare analyze_results=
 declare -i debugonly=0
-declare force_cleanup_timeout=
 declare -i take_prometheus_snapshot=0
 declare unique_job_prefix=
 declare snapshot_date_format='%Y_%m_%dT%H_%M_%S%z'
@@ -66,12 +65,12 @@ declare prometheus_snapshot_start_ts=
 
 declare -a runtimeclasses=('' 'kata')
 declare -a extra_clusterbuster_args=()
+declare -A known_clusterbuster_options=()
 
 declare -i fail=0
 declare -i interrupted=0
 declare -i timedout=0
 declare -i counter=0
-declare -i global_counter=0
 declare -i hard_fail_on_error=0
 declare -i restart=0
 declare -i started_prom_capture=0
@@ -241,6 +240,7 @@ function finis() {
 	starting_timestamp=
 	report_ci_results -s "$status" -t "$saved_starting_timestamp" -e "$ending_timestamp"
 	if [[ -n "$analyze_results" ]] ; then
+	    # shellcheck disable=SC2086
 	    "$__analyze__" ${analysis_format:-r "$analysis_format"} -o "$analyze_results" "$artifactdir"
 	fi
 	if [[ -n "$python_venv" && -d "$python_venv" ]] ; then
@@ -469,6 +469,7 @@ EOF
 function set_pin_node() {
     local setting="${1:-}"
     if [[ $setting = *'='* ]] ; then
+	# shellcheck disable=SC2206
 	local -a vals=(${setting/=/ })
 	case "${vals[0]}" in
 	    server) server_pin_node="${vals[1]}" ;;
@@ -481,6 +482,17 @@ function set_pin_node() {
 	client_pin_node=$setting
 	sync_pin_node=$setting
     fi
+}
+
+function check_clusterbuster_option() {
+    local option=$1
+    if [[ -z "${known_clusterbuster_options[*]}" ]] ; then
+	local arg
+	while read -r arg ; do
+	    known_clusterbuster_options[$arg]=1
+	done <<< "$("$__clusterbuster__" -h 2>&1 |grep -oEe '^[ \t]*--[-_[:lower:]]+' |sed -e 's/[ \t]//g' -e 's/[-_]//g' |sort |uniq)"
+    fi
+    [[ -n "${known_clusterbuster_options[$option]:-}" ]]
 }
 
 function process_option() {
@@ -518,7 +530,11 @@ function process_option() {
 	# Unknown option -- can we delegate?
 	*)
 	    if ! call_api -A -a process_option "$option" ; then
-		extra_clusterbuster_args+=("--$option")
+		if check_clusterbuster_option "$noptname1" ; then
+		    extra_clusterbuster_args+=("--$option")
+		else
+		    fatal "Unknown option $option"
+		fi
 	    fi
 	    ;;
     esac
@@ -712,7 +728,7 @@ function run_clusterbuster() {
 }
 
 if [[ -z "${workloads[*]}" ]] ; then
-    workloads=($(print_workloads))
+    readarray -t workloads <<< "$(print_workloads)"
 fi
 
 bad_workload=0

--- a/clusterbuster
+++ b/clusterbuster
@@ -414,6 +414,14 @@ $(print_workloads_supporting_reporting '                        - ')
                         Arrange for the liveness probe to sleep for specified
                         time.
 
+    Virtualization Options:
+       --virtiofsd-writeback=[0,1]
+                        Use writeback caching for virtiofsd (default $virtiofsd_writeback).
+       --virtiofsd-direct=[0,1]
+                        Allow use of direct I/O for virtiofsd (default $virtiofsd_direct).
+       --virtiofsd-threadpoolsize=n
+                        Use the specified thread pool size for virtiofsd (default 1).
+
     Tuning object creation (short equivalents):
        --scale-ns=[0,1] Scale up the number of namespaces vs.
                         create new ones (default 0).
@@ -427,8 +435,6 @@ $(print_workloads_supporting_reporting '                        - ')
                         Index number of first secret to be created
        --first_namespace=N
                         Index number of first namespace to be created
-       --first_deployment=N
-                        Index number of first pod to be created
        --pod-prefix=prefix
                         Prefix all created pods with this prefix.
        --sleep=N        Number of seconds between object creations
@@ -863,86 +869,6 @@ function ___OC() {
     if ! __OC "$@" ; then
 	fatal "$OC $* failed!"
     fi
-}
-
-# The big red button if something goes wrong.
-
-function childrenof() {
-    IFS=' '
-    function is_descendent() {
-	local -i child=$1
-	local ancestor=$2
-	if ((child == ancestor)) ; then
-	    true
-	else
-	    parent=${ps_parents[$child]:-1}
-	    case "$parent" in
-		1)           false ;;
-		"$ancestor") true  ;;
-		*)           is_descendent "$parent" "$ancestor" ;;
-	    esac
-	fi
-    }
-    local -A exclude=()
-    local OPTIND=0
-    while getopts 'e:' opt "$@" ; do
-	case "$opt" in
-	    e) exclude[$OPTARG]=1 ;;
-	    *)                    ;;
-	esac
-    done
-    shift $((OPTIND-1))
-    local target=$1
-    local -A ps_parents=()
-    local -A ps_commands=()
-    local ppid
-    local pid
-    local command
-    local ignore
-    while read -r pid ppid command ignore; do
-	ps_parents["$pid"]=$ppid
-	ps_commands["$pid"]=$command
-    done <<< "$(ps -axo pid,ppid,command | tail -n +2)"
-    for pid in "${!ps_parents[@]}" ; do
-	# Don't kill loggers and the report generator; we still want
-	# output even if there's a failure.
-	if [[ -z "${!exclude[$pid]:-}" && "${ps_commands[$pid]}" != 'tee'* && "${ps_commands[$pid]}" != *'clusterbuster-report'* ]] ; then
-	    if is_descendent "$pid" "$target" ; then
-		echo "$pid"
-	    fi
-	fi
-    done
-}
-
-function killthemall() {
-    echo "FATAL: ${*:-Exiting!}" 1>&2
-    # Selectively kill all processes.  We don't want to kill
-    # processes between us and the root, or processes that
-    # aren't actually clusterbuster (e. g. reporting)
-    # Also, RHEL 8 doesn't support kill -<pgrp> syntax
-    local -a pids_to_kill=()
-    readarray -t pids_to_kill <<< "$(childrenof -e "$BASHPID" $$)"
-    # killthemall can livelock under the wrong circumstances.
-    # Make sure that that doesn't happen; we want to control
-    # our own exit.
-    trap : TERM
-    if [[ -n "${pids_to_kill[*]}" ]] ; then
-	/bin/kill -TERM "${pids_to_kill[@]}" >/dev/null 2>&1
-	if (( $$ == BASHPID )) ; then
-	    wait
-	    local -i tstart
-	    tstart=$(date +%s)
-	    until [[ -z "$(ps -o pid "${pids_to_kill[@]}" | awk '{print $1}' | grep -v "^${$}$" | tail -n +2)" ]] ; do
-		sleep 1
-		if (( $(date +%s) - tstart > 60 )) ; then
-		    warn "Unable to terminate all processes!"
-		    ps "${pids_to_kill[@]}" 1>&2
-		    break
-		fi
-	    done
-	fi
-    fi
-    exit 1
 }
 
 ################################################################

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -62,8 +62,6 @@ function sysbench_calculate_logs_required() {
 function sysbench_help_options() {
     cat <<'EOF'
     Sysbench General Options:
-       --sysbench-general-options=<options>
-                        Space or comma separated general Sysbench options
        --sysbench-generic-options=<options>
                         Space or comma separated generic Sysbench options
        --sysbench-fileio-tests=<modes>
@@ -92,7 +90,6 @@ function sysbench_process_options() {
 	read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
 	case "$noptname1" in
 	# Sysbench options
-	    sysbenchgeneraloptions)     ___sysbench_generic_options+=(${optvalue//,/ })	;;
 	    sysbenchgenericoptions)     ___sysbench_generic_options+=(${optvalue//,/ })	;;
 	    sysbenchfileiooptions)      ___sysbench_fileio_options+=(${optvalue//,/ })	;;
 	    sysbenchfileiotests)	___sysbench_fileio_test_string=$optvalue	;;
@@ -113,8 +110,7 @@ function sysbench_supports_reporting() {
 
 function sysbench_report_options() {
     cat <<EOF
-"sysbench_general_options": [$(quote_list "${___sysbench_general_options[@]}")],
-"sysbench_Generic_options": [$(quote_list "${___sysbench_generic_options[@]}")],
+"sysbench_generic_options": [$(quote_list "${___sysbench_generic_options[@]}")],
 "sysbench_fileio_options": [$(quote_list "${___sysbench_fileio_options[@]}")],
 "sysbench_fileio_tests": [$(quote_list ${___sysbench_fileio_test_string//,/ })]
 EOF

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -89,8 +89,6 @@ function uperf_calculate_logs_required() {
 function uperf_help_options() {
     cat <<'EOF'
     Uperf Options:
-       --workload-runtime
-                       How many seconds to run each test for.
        --pin_node=server=<node>
                        Specify node to which the server is bound.
      The following options take a comma-separated list of each


### PR DESCRIPTION
- (run-kata-perf-suite) Don't acccept unused options not known to clusterbuster
- (clusterbuster) Fix up some missing/duplicate/incorrect help strings
- (libclusterbuster.sh) Move killall to libclusterbuster.sh
- (libclusterbuster.sh) Fix use of debug when debugging not enabled
- (all) Run shellcheck