### PR TITLE
Fix inadvertent timing error caused by change to sync API

### DIFF
--- a/lib/clusterbuster/pod_files/sync.pl
+++ b/lib/clusterbuster/pod_files/sync.pl
@@ -176,7 +176,7 @@ if ($sync_count == 0) {
 		my ($command) = lc substr($tbuf, 0, 4);
 		$tbuf =~ s/^....\s+//;
 		if ($command eq 'time')  {
-		    my ($ignore, $ts, $ignore) = split(/ +/, $tbuf);
+		    my ($ignore, $ignore, $ts, $ignore) = split(/ +/, $tbuf);
 		    push @clients, [$client, "$ts " . ytime()];
 		} elsif ($command eq 'rslt') {
 		    if (defined $tmp_sync_file_base) {


### PR DESCRIPTION
Change to do_sync() implementation resulted in an extra token being passed which confused the timing code.