### PR TITLE
Do one initial sync per container rather than per process.

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -893,11 +893,12 @@ function create_sync_service_if_needed() {
     local namespace=$1
     local sync_count=${2:-0}
     local sync_clients=${3:-0}
+    local initial_sync_clients=${4:-$sync_clients}
     if ((sync_count <= 0)) ; then return; fi
     if get_sync -q ; then
 	if [[ $namespace = "${namespaces_to_create[0]:-}" ]] ; then
 	    create_service -h "$sync_namespace" "${sync_namespace}-sync" "$sync_port"
-	    create_sync_deployment "$sync_namespace" "$sync_count" $((sync_clients * ${#namespaces_to_create[@]}))
+	    create_sync_deployment "$sync_namespace" "$sync_count" "$((sync_clients * ${#namespaces_to_create[@]}))" "$((initial_sync_clients * ${#namespaces_to_create[@]}))"
 	fi
 	create_external_service "$namespace" "${namespace}-sync" "$sync_port" "$global_sync_service"
     fi
@@ -2421,6 +2422,7 @@ function create_container_sync() {
     local namespace=$1
     local sync_count=${4:-1}
     local expected_clients=$5
+    local initial_expected_clients=$6
     cat <<EOF
 - name: ${namespace}
   image_pull_policy: $image_pull_policy
@@ -2440,6 +2442,7 @@ $(indent 2 bootstrap_command_yaml sync.pl)
   - "$postdelay"
   - "$sync_port"
   - "$expected_clients"
+  - "$initial_expected_clients"
   - "$sync_count"
 $(indent 2 volume_mounts_yaml "$namespace" 0 0)
 EOF

--- a/lib/clusterbuster/pod_files/classic.pl
+++ b/lib/clusterbuster/pod_files/classic.pl
@@ -5,7 +5,8 @@ use strict;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
-my ($sleep_time) = parse_command_line(@ARGV);
+my ($sleep_time, $processes) = parse_command_line(@ARGV);
+initialize_timing();
 
 sub runit() {
     my $pass = 0;
@@ -14,7 +15,6 @@ sub runit() {
     my ($cfail) = 0;
     my ($refused) = 0;
     my $time_overhead = 0;
-    initialize_timing();
     $SIG{TERM} = sub { POSIX::_exit(0); };
 
     timestamp("Clusterbuster pod starting");
@@ -30,4 +30,4 @@ sub runit() {
 		   $data_end_time - $data_start_time,
 		   $user, $sys);
 }
-run_workload(\&runit);
+run_workload(\&runit, $processes);

--- a/lib/clusterbuster/pod_files/client.pl
+++ b/lib/clusterbuster/pod_files/client.pl
@@ -7,6 +7,7 @@ my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
 my ($srvhost, $connect_port, $data_rate, $bytes, $bytes_max, $msg_size, $xfertime, $xfertime_max) = parse_command_line(@ARGV);
+initialize_timing();
 
 sub runit() {
     my ($data_start_time, $data_end_time, $elapsed_time, $end_time, $user, $sys, $cuser, $csys);
@@ -22,7 +23,6 @@ sub runit() {
     my $ex2 = 0;
     my ($cfail) = 0;
     my ($refused) = 0;
-    initialize_timing();
 
     $SIG{TERM} = sub { POSIX::_exit(0); };
     timestamp("Clusterbuster client starting");

--- a/lib/clusterbuster/pod_files/cpusoaker.pl
+++ b/lib/clusterbuster/pod_files/cpusoaker.pl
@@ -6,9 +6,9 @@ my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
 my ($processes, $runtime) = parse_command_line(@ARGV);
+initialize_timing();
 
 sub runit() {
-    initialize_timing();
     $SIG{TERM} = sub { kill 'KILL', -1; POSIX::_exit(0); };
     my ($iterations) = 0;
     my ($loops_per_iteration) = 10000;

--- a/lib/clusterbuster/pod_files/memory.pl
+++ b/lib/clusterbuster/pod_files/memory.pl
@@ -7,10 +7,10 @@ my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
 my ($processes, $memory, $runtime) = parse_command_line(@ARGV);
+initialize_timing();
 $SIG{TERM} = sub { kill 'KILL', -1; POSIX::_exit(0); };
 
 sub runit() {
-    initialize_timing();
     my ($mib_blk) = '';
     my ($kib_blk) = '';
     my ($leftover_blk) = '';

--- a/lib/clusterbuster/pod_files/sync.pl
+++ b/lib/clusterbuster/pod_files/sync.pl
@@ -20,10 +20,14 @@ GetOptions("v!"  => \$verbose,
 	   "f:s" => \$sync_file,
 	   "e:s" => \$error_file);
 
-my ($listen_port, $expected_clients, $sync_count) = @ARGV;
+my ($listen_port, $expected_clients, $initial_expected_clients, $sync_count) = @ARGV;
 if ($sync_count < 1 || $expected_clients < 1) {
     timestamp("Sync requested with no clients or no syncs");
     POSIX::exit(0);
+}
+
+if ($initial_expected_clients <= 0) {
+    $initial_expected_clients = $expected_clients;
 }
 
 sub xtime() {
@@ -165,8 +169,8 @@ sub reply_timestamp($$\@) {
     timestamp("Sending sync time took $et seconds");
 }
 
-sub sync_one($$$$$) {
-    my ($sock, $tmp_sync_file_base, $tmp_error_file, $start_time, $base_start_time) = @_;
+sub sync_one($$$$$$) {
+    my ($sock, $tmp_sync_file_base, $tmp_error_file, $start_time, $base_start_time, $expected_clients) = @_;
     timestamp("Listening on port $listen_port");
     listen($sock, 5) || die "listen: $!";
     printf STDERR "Expect $expected_clients client%s\n", $expected_clients == 1 ? '' : 's';
@@ -269,7 +273,7 @@ if ($sync_count == 0) {
 	# clients and close them manually.
 	my $child = fork();
 	if ($child == 0) {
-	    sync_one($sock, $tmp_sync_file_base, $tmp_error_file, $start_time, $base_start_time);
+	    sync_one($sock, $tmp_sync_file_base, $tmp_error_file, $start_time, $base_start_time, $first_pass ? $initial_expected_clients : $expected_clients);
 	} elsif ($child < 1) {
 	    timestamp("Fork failed: $!");
 	    POSIX::_exit(1);

--- a/lib/clusterbuster/pod_files/synctest.pl
+++ b/lib/clusterbuster/pod_files/synctest.pl
@@ -5,10 +5,10 @@ use strict;
 my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
-my ($sync_count, $sync_cluster_count, $sync_sleep) = parse_command_line(@ARGV);
+my ($sync_count, $sync_cluster_count, $sync_sleep, $processes) = parse_command_line(@ARGV);
+initialize_timing();
 
 sub runit() {
-    initialize_timing();
     my ($data_start_time) = xtime();
     my ($ucpu0, $scpu0) = cputime();
     foreach my $i (1..$sync_count) {
@@ -27,4 +27,4 @@ sub runit() {
     report_results($data_start_time, $data_end_time, $data_end_time - $data_start_time, $ucpu1, $scpu1);
 }
 
-run_workload(\&runit);
+run_workload(\&runit, $processes);

--- a/lib/clusterbuster/pod_files/sysbench.pl
+++ b/lib/clusterbuster/pod_files/sysbench.pl
@@ -7,15 +7,13 @@ my ($dir) = $ENV{'BAK_CONFIGMAP'};
 require "$dir/clientlib.pl";
 
 my ($processes, $rundir, $runtime, $sysbench_generic_args, $sysbench_cmd, $sysbench_fileio_args, $sysbench_modes) = parse_command_line(@ARGV);
-
-$SIG{TERM} = sub() { docleanup() };
+my ($localrundir);
 
 initialize_timing();
-my ($localrundir) = sprintf('%s/%s/%d', $rundir, podname(), $$);
 
 sub removeRundir() {
-    if (-d "$localrundir") {
-	open(CLEANUP, "-|", "rm -rf '$localrundir'");
+    if (-d $localrundir) {
+	open(CLEANUP, "-|", "rm", "-rf", $localrundir);
 	while (<CLEANUP>) {
 	    1;
 	}
@@ -42,6 +40,7 @@ my (%units_multiplier) = (
     );
 
 sub runit() {
+    $SIG{TERM} = sub() { docleanup() };
     my ($files) = 0;
     my ($totalbytes) = 0;
     my ($seconds) = 0;
@@ -49,6 +48,7 @@ sub runit() {
     my ($et) = 0;
     my (@known_sysbench_fileio_modes) = qw(seqwr seqrewr seqrd rndrd rndwr rndrw);
     my ($iterations) = 0;
+    $localrundir = sprintf('%s/%s/%d', $rundir, podname(), $$);
     my ($loops_per_iteration) = 10000;
     if ($sysbench_modes) {
         @known_sysbench_fileio_modes = split(/ +/, $sysbench_modes);

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -19,7 +19,7 @@
 ################################################################
 
 function classic_arglist() {
-    mk_yaml_args "${workload_run_time:-10}"
+    mk_yaml_args "${workload_run_time:-10}" "$processes_per_pod"
 }
 
 function classic_create_deployment() {
@@ -29,7 +29,8 @@ function classic_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * count))"
+    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * processes_per_pod * replicas * count))" \
+				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a classic_arglist -e classic.pl \
 				   "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod"

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -29,7 +29,8 @@ function cpusoaker_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))"
+    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))" \
+				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a cpusoaker_arglist -e cpusoaker.pl \
 				   "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod"

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -44,7 +44,8 @@ function files_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 8 "$((containers_per_pod * processes_per_pod * replicas * count))"
+    create_sync_service_if_needed "$namespace" 8 "$((containers_per_pod * processes_per_pod * replicas * count))" \
+				   "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_drop_cache_deployment "$namespace" "$workload" "$instance" "$replicas"
 	create_standard_deployment -e files.pl -a files_arglist -p \

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -31,7 +31,8 @@ function memory_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))"
+    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))" \
+				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a memory_arglist -e memory.pl \
 				   "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod"

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -24,7 +24,7 @@ declare -g ___synctest_cluster_count=1
 declare -g ___synctest_sleep=0
 
 function synctest_arglist() {
-    mk_yaml_args "$___synctest_count" "$___synctest_cluster_count" "$___synctest_sleep"
+    mk_yaml_args "$___synctest_count" "$___synctest_cluster_count" "$___synctest_sleep" "$processes_per_pod"
 }
 
 function synctest_create_deployment() {
@@ -34,7 +34,9 @@ function synctest_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" "$(((___synctest_count * ___synctest_cluster_count) + 2))" "$((containers_per_pod * replicas * processes_per_pod * count))"
+    create_sync_service_if_needed "$namespace" "$(((___synctest_count * ___synctest_cluster_count) + 2))" \
+				  "$((containers_per_pod * replicas * processes_per_pod * count))" \
+				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a synctest_arglist -e synctest.pl \
 				   "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod"

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -38,7 +38,9 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" "$(( (${#___sysbench_fileio_tests[@]} * 3) + 2))" "$((containers_per_pod * replicas * count))"
+    create_sync_service_if_needed "$namespace" "$(( (${#___sysbench_fileio_tests[@]} * 3) + 2))" \
+				  "$((containers_per_pod * processes_per_pod * replicas * count))" \
+				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq $first_deployment $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a sysbench_arglist -e sysbench.pl \
 				   "$namespace" "$instance" "$secret_count" "$replicas" "$containers_per_pod"


### PR DESCRIPTION
- Simplifies startup logic
- Reduces the overhead of initial time synchronization
- Allows time synchronization to happen earlier in startup, and hence allows more accurate startup timing