### PR TITLE
Workaround for any erratic DNS behavior

### DIFF
--- a/lib/clusterbuster/pod_files/clientlib.pl
+++ b/lib/clusterbuster/pod_files/clientlib.pl
@@ -188,6 +188,21 @@ sub initialize_timing(;@) {
     $crtime += $baseoffset;
 }
 
+sub resolve_host($) {
+    my ($host) = @_;
+    while (1) {
+        my ($fname,$faliases,$ftype,$flen,$faddr) = gethostbyname($host);
+	if (length($faddr) < 4) {
+	    timestamp("gethostbyname $host FAILED!");
+	    sleep(1);
+	} else {
+	    my ($dqhost) = inet_ntoa($faddr);
+	    timestamp("gethostbyname $host -> $dqhost");
+	    return $dqhost;
+	}
+    }
+}
+
 sub connect_to($$) {
     my ($addr, $port) = @_;
     my ($connected) = 0;

--- a/lib/clusterbuster/pod_files/uperf-client.pl
+++ b/lib/clusterbuster/pod_files/uperf-client.pl
@@ -36,6 +36,10 @@ sub process_file($$%) {
     close OUT || die "Can't close $outfile: $!\n";
 }
 
+my ($orig_srvhost) = $srvhost;
+$srvhost = resolve_host($orig_srvhost);
+timestamp("srvhost $orig_srvhost resolves to $srvhost");
+
 my (%options) = (
     'srvhost' => $srvhost,
     'runtime' => 1,
@@ -175,7 +179,7 @@ sub runit() {
 		push @failed_cases, $test_name;
 	    }
 	}
-	if (! close(RUN)) {
+	if (! close(RUN) || $failed) {
 	    timestamp("Uperf failed: $! $?");
 	    exit(1);
 	}


### PR DESCRIPTION
If DNS behaves erratically on startup, an initial resolution may succeed but a later one fail.  This caused failures with uperf in CI.