### PR TITLE
Clusterbuster analysis: handle output spread across multiple directories

### DIFF
--- a/analyze-clusterbuster-report
+++ b/analyze-clusterbuster-report
@@ -20,11 +20,17 @@ from lib.clusterbuster.analysis.ClusterBusterAnalysis import ClusterBusterAnalys
 from lib.clusterbuster.loader.ClusterBusterLoader import ClusterBusterLoader
 
 parser = argparse.ArgumentParser(description='Analyze ClusterBuster report')
+analysis_formats = ClusterBusterAnalysis.list_analysis_formats()
 
 parser.add_argument("-o", "--outfile", default=None, type=str, metavar='file', help='Output filename')
-parser.add_argument("-r", "--report-type", default=None, type=str, metavar='format', help='Analysis format')
+parser.add_argument('--list_formats', action='store_true', help='List available report formats')
+parser.add_argument("-r", "--report-type", default=None, type=str, metavar='format',
+                    choices=analysis_formats, help=f'Analysis format: one of {", ".join(analysis_formats)}')
 parser.add_argument("files", metavar='file', type=str, nargs='*', help='Files to process')
 args = parser.parse_args()
+if args.list_formats:
+    print('\n'.join(sorted(analysis_formats)))
+    sys.exit(1)
 
 
 def do_analyze_clusterbuster(f, data):

--- a/clusterbuster-report
+++ b/clusterbuster-report
@@ -21,8 +21,8 @@ from lib.clusterbuster.reporter.ClusterBusterReporter import ClusterBusterReport
 parser = argparse.ArgumentParser(description='Generate ClusterBuster report')
 report_formats = ClusterBusterReporter.list_report_formats()
 
-parser.add_argument('-o', '--format', '--output_format', '--output', default='summary', type=str,
-                    choices=report_formats)
+parser.add_argument('-o', '--format', '--output_format', '--output', default='summary', metavar='format', type=str,
+                    choices=report_formats, help=f'Report format: one of {", ".join(report_formats)}')
 parser.add_argument('--list_formats', action='store_true', help='List available report formats')
 parser.add_argument("files", metavar='file', type=str, nargs='*', help='Files to process')
 

--- a/lib/clusterbuster/analysis/ClusterBusterAnalysis.py
+++ b/lib/clusterbuster/analysis/ClusterBusterAnalysis.py
@@ -173,6 +173,10 @@ class ClusterBusterAnalysis:
             report_type = 'ci'
         self._report_type = report_type
 
+    @staticmethod
+    def list_analysis_formats():
+        return ['ci', 'spreadsheet', 'summary']
+
     def Analyze(self):
         report = dict()
         metadata = dict()
@@ -182,7 +186,7 @@ class ClusterBusterAnalysis:
             metadata = self._data['metadata']
         if 'status' in self._data:
             status = self._data['status']
-        for workload, workload_data in self._data.items():
+        for workload, workload_data in sorted(self._data.items()):
             if workload == 'metadata' or workload == 'status':
                 continue
             try:

--- a/lib/clusterbuster/analysis/spreadsheet/analyze_spreadsheet_generic.py
+++ b/lib/clusterbuster/analysis/spreadsheet/analyze_spreadsheet_generic.py
@@ -41,7 +41,7 @@ class SpreadsheetAnalysis(ClusterBusterAnalyzeSummaryGeneric):
         answer = ""
         if dimension == 'Overall':
             answer += """Total
-Metric\tKata\trunc
+Metric\tKata\trunc\tratio
 """
             for v in self._sp_variables:
                 var = v['var']
@@ -49,7 +49,8 @@ Metric\tKata\trunc
                 multiplier = v.get('multiplier', 1)
                 answer += '\t'.join([name,
                                      self.print_safe(data[var], 'kata', True, multiplier),
-                                     self.print_safe(data[var], 'runc', True, multiplier)]) + "\n"
+                                     self.print_safe(data[var], 'runc', True, multiplier),
+                                     self.print_safe(data[var], 'ratio', True)]) + "\n"
             answer += """
 Total (Ratio)
 Metric\tMin ratio\tAvg ratio\tMax ratio
@@ -70,12 +71,13 @@ Metric\tMin ratio\tAvg ratio\tMax ratio
                 multiplier = v.get('multiplier', 1)
                 answer += f"""
 {name}{unit}
-{dimension.replace('By ', '')}\tKata\trunc
+{dimension.replace('By ', '')}\tKata\trunc\tratio
 """
                 for value in data[var]['kata'].keys():
                     answer += '\t'.join([str(value),
                                          self.print_safe(data[var], 'kata', value, multiplier),
-                                         self.print_safe(data[var], 'runc', value, multiplier)]) + "\n"
+                                         self.print_safe(data[var], 'runc', value, multiplier),
+                                         self.print_safe(data[var], 'ratio', value)]) + "\n"
             for v in self._sp_variables:
                 var = v['var']
                 name = v.get('name', var)

--- a/lib/clusterbuster/analysis/spreadsheet/files_analysis.py
+++ b/lib/clusterbuster/analysis/spreadsheet/files_analysis.py
@@ -30,12 +30,13 @@ class files_analysis(FilesAnalysisBase):
 uuid: {report['uuid']}
 Times in seconds
 
-Op\tKata\trunc
+Op\tKata\trunc\tratio
 """
         for op in ['create', 'read', 'remove']:
             answer += '\t'.join([op,
                                  self._prettyprint(report['kata'][op]['elapsed_time'], precision=3, base=0),
-                                 self._prettyprint(report['runc'][op]['elapsed_time'], precision=3, base=0)]) + '\n'
+                                 self._prettyprint(report['runc'][op]['elapsed_time'], precision=3, base=0),
+                                 self._prettyprint(report['ratio'][op]['elapsed_time'], precision=3, base=0)]) + '\n'
         answer += """
 Ratio
 Op\tMin ratio\tAvg ratio\tMax ratio

--- a/lib/clusterbuster/analysis/summary/analyze_generic.py
+++ b/lib/clusterbuster/analysis/summary/analyze_generic.py
@@ -53,8 +53,6 @@ class ClusterBusterAnalyzeSummaryGeneric(ClusterBusterAnalyzeOne):
     def __report_one_dimension(self, accumulator: dict):
         answer = dict()
         for variable in self._variables:
-            min_ratio = None
-            max_ratio = None
             if variable not in accumulator:
                 continue
             if variable not in answer:
@@ -77,7 +75,7 @@ class ClusterBusterAnalyzeSummaryGeneric(ClusterBusterAnalyzeOne):
                 min_ratio = None
                 max_ratio = None
                 for i in range(len(value['runc']['values'])):
-                    if 'kata' not in value or i not in value['kata']['values'] or i not in value['runc']['values']:
+                    if 'kata' not in value or i >= len(value['kata']['values']):
                         continue
                     ratio = value['kata']['values'][i] / value['runc']['values'][i]
                     if min_ratio is None or ratio < min_ratio:

--- a/lib/clusterbuster/loader/fio_loader.py
+++ b/lib/clusterbuster/loader/fio_loader.py
@@ -51,4 +51,3 @@ class fio_loader(LoadOneReport):
                         root['total']['iops'] = 0
                     root[op]['iops'] = result[op]['io_rate']
                     root['total']['iops'] += result[op]['io_rate']
-        print(self._answer, file=sys.stderr)


### PR DESCRIPTION
- Enable full analysis report for run split across multiple directories.
- Fix ratio generation
- Remove spurious debugging print
- More straightforwardly display options for report formats