### PR TITLE
Suppress workload unknown argument checking for now.

### DIFF
--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -110,7 +110,7 @@ function files_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
     if (( ___file_block_size <= 0)) ; then
 	___file_block_size=___file_size

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -164,7 +164,7 @@ function fio_process_options() {
 	help "Can't find job file $___fio_job_file"
     fi
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
     if [[ -n "${fioblksize:-}" ]] ; then
 	readarray -t ___fio_blocksizes <<< "$(parse_size ${fioblksize//,/ })"

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -80,7 +80,7 @@ function memory_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
 }
 

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -101,7 +101,7 @@ function server_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
     if (( ___msg_size <= 0 )) ; then
 	fatal "Message size must be positive, exiting!"

--- a/lib/clusterbuster/workloads/simple.workload
+++ b/lib/clusterbuster/workloads/simple.workload
@@ -198,7 +198,7 @@ function simple-log_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
 }
 

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -82,7 +82,7 @@ function synctest_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
 }
 

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -99,7 +99,7 @@ function sysbench_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
     for ftest in ${___sysbench_fileio_test_string//,/ } ; do
 	___sysbench_fileio_tests[$ftest]=1

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -128,7 +128,7 @@ function uperf_process_options() {
 	esac
     done
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
-	help "${unknown_opts[@]}"
+	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
     if (( ___uperf_msg_sizes <= 0 )) ; then
 	fatal "Message size must be positive, exiting!"


### PR DESCRIPTION
The workload unknown argument checking doesn't work very well if the same arguments are passed to every job (as the CI script does).  Until there's a better fix, simply print a notice about the unknown arguments.