### PR TITLE
BUGFIX Correctly fail if the reporting step fails (#67)

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -2871,7 +2871,6 @@ function do_logging() {
     fi
     if (( get_logs_pid > 1 )) ; then
 	wait "$get_logs_pid" 2>/dev/null
-	status=$?
     fi
 }
 


### PR DESCRIPTION
Clusterbuster should fail if the reporting fails even if the run proper succeeds.

Fixes #67 