### PR TITLE
Clusterbuster: Eliminate requirement for explicit sync count

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -897,16 +897,14 @@ function get_sync() {
     fi
 }
 
-function create_sync_service_if_needed() {
+function create_sync_service() {
     local namespace=$1
-    local sync_count=${2:-0}
-    local sync_clients=${3:-0}
-    local initial_sync_clients=${4:-$sync_clients}
-    if ((sync_count <= 0)) ; then return; fi
+    local sync_clients=${2:-0}
+    local initial_sync_clients=${3:-$sync_clients}
     if get_sync -q ; then
 	if [[ $namespace = "${namespaces_to_create[0]:-}" ]] ; then
 	    create_service -h "$sync_namespace" "${sync_namespace}-sync" "$sync_port" "$sync_ns_port"
-	    create_sync_deployment "$sync_namespace" "$sync_count" "$((sync_clients * ${#namespaces_to_create[@]}))" "$((initial_sync_clients * ${#namespaces_to_create[@]}))"
+	    create_sync_deployment "$sync_namespace" "$((sync_clients * ${#namespaces_to_create[@]}))" "$((initial_sync_clients * ${#namespaces_to_create[@]}))"
 	fi
 	create_external_service "$namespace" "${namespace}-sync" "$global_sync_service" "$sync_port" "$sync_ns_port"
     fi
@@ -1649,8 +1647,6 @@ function create_standard_containers() {
     local sync_service=
     local sync_port_num=
     local sync_ns_port_num=
-    local yaml_args
-    yaml_args="$(mk_yaml_args)"
     IFS=: read -r sync_service sync_port_num sync_ns_port_num <<< "$(get_sync)"
     for container in $(seq 0 $((containers - 1))) ; do
 	cat <<EOF
@@ -2434,9 +2430,8 @@ function create_standard_deployment() {
 
 function create_container_sync() {
     local namespace=$1
-    local sync_count=${4:-1}
-    local expected_clients=$5
-    local initial_expected_clients=$6
+    local expected_clients=$4
+    local initial_expected_clients=$5
     cat <<EOF
 - name: ${namespace}
   image_pull_policy: $image_pull_policy
@@ -2456,14 +2451,12 @@ $(indent 2 standard_environment)
   - "$sync_ns_port"
   - "$expected_clients"
   - "$initial_expected_clients"
-  - "$sync_count"
 $(indent 2 volume_mounts_yaml "$namespace" 0 0)
 EOF
 }
 
 function create_sync_deployment() {
     local namespace=$1; shift
-    local sync_count=$1; shift
     create_object -t Pod -n "$namespace" "${namespace}-sync" <<EOF
 apiVersion: v1
 kind: Pod
@@ -2475,7 +2468,7 @@ $(indent 2 standard_labels_yaml 'sync' "$namespace")
   selector:
     matchLabels:
       app: ${namespace}
-$(create_container_function=create_container_sync create_spec -P -c sync -r '' "$namespace" 0 0 "$sync_count" "$@")
+$(create_container_function=create_container_sync create_spec -P -c sync -r '' "$namespace" 0 0 "$@")
   restartPolicy: Never
 EOF
 }

--- a/examples/clusterbuster/cpusoaker-perl
+++ b/examples/clusterbuster/cpusoaker-perl
@@ -1,0 +1,13 @@
+# Run as
+# clusterbuster -f cpusoaker
+
+cleanup
+workload=cpusoaker
+workloadruntime=10
+cpusoaker-workload=perl
+precleanup=1
+no-report-object-creation
+deps-per-namespace=8
+processes=3
+namespaces=1
+exit_at_end

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -31,7 +31,7 @@ function classic_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * processes_per_pod * replicas * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a classic_arglist \

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -42,7 +42,7 @@ function cpusoaker_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * replicas * processes_per_pod * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a cpusoaker_arglist \

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -47,7 +47,7 @@ function files_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 8 "$((containers_per_pod * processes_per_pod * replicas * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				   "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_drop_cache_deployment "$namespace" "$workload" "$instance" "$replicas"

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -54,8 +54,7 @@ function fio_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    local -i syncs_needed=$((2 + (${#___fio_patterns[@]} * ${#___fio_blocksizes[@]} * ${#___fio_iodepths[@]} * ${#___fio_directs[@]} * ${#___fio_fdatasyncs[@]} * ${#___fio_ioengines[@]}) ))
-    create_sync_service_if_needed "$namespace" "$syncs_needed" "$((containers_per_pod * processes_per_pod * replicas * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_drop_cache_deployment "$namespace" "$workload" "$instance" "$replicas"

--- a/lib/clusterbuster/workloads/logger.workload
+++ b/lib/clusterbuster/workloads/logger.workload
@@ -37,7 +37,7 @@ function logger_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * replicas * processes_per_pod * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a logger_arglist \

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -34,7 +34,7 @@ function memory_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" 2 "$((containers_per_pod * replicas * processes_per_pod * count))" \
+    create_sync_service "$namespace" "$((containers_per_pod * replicas * processes_per_pod * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	create_standard_deployment -a memory_arglist \

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -62,7 +62,7 @@ function server_create_deployment() {
     local containers_per_pod=${5:-1}
     local replicas_per_server=$replicas
     local -i instance
-    create_sync_service_if_needed "$namespace" 3 "$((containers_per_pod * replicas * count))" "$(((containers_per_pod * replicas * count)+count))"
+    create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(((containers_per_pod * replicas * count)+count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	if [[ -z "${___server_interface}" ]] ; then

--- a/lib/clusterbuster/workloads/synctest.workload
+++ b/lib/clusterbuster/workloads/synctest.workload
@@ -37,7 +37,7 @@ function synctest_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" "$(((___synctest_count * ___synctest_cluster_count) + 2))" \
+    create_sync_service "$namespace" \
 				  "$((containers_per_pod * replicas * processes_per_pod * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -42,7 +42,7 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" "$(( (${#___sysbench_fileio_tests[@]} * 3) + 2))" \
+    create_sync_service "$namespace" \
 				  "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -58,7 +58,7 @@ function uperf_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    create_sync_service_if_needed "$namespace" $((${#___uperf_tests[@]} + 2)) "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
+    create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do
 	if [[ -z "${___uperf_interface}" ]] ; then


### PR DESCRIPTION
There is no need for an explicit sync count; it just adds complexity.  The first sync step is always time synchronization; all commands after that are sync commands, except that the final command is rslt.  Any fail commands are always handled immediately.