### PR TITLE
Kubernetes 1.22/OpenShift 4.11 security policy compatibility

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -177,6 +177,7 @@ declare -a pod_annotations=()
 declare -A injected_errors=()
 declare cb_tempdir=
 declare force_cleanup_timeout=
+declare default_namespace_policy=restricted
 
 declare OC=${OC:-${KUBECTL:-}}
 OC=${OC:-$(type -p oc)}
@@ -856,6 +857,12 @@ function generate_workload_metadata() {
 
 function generate_environment() {
     call_api -w "$requested_workload" -s generate_environment
+}
+
+function namespace_policy() {
+    local policy
+    policy=$(call_api -w "$requested_workload" -s namespace_policy)
+    echo ${policy:-${default_namespace_policy}}
 }
 
 ################################################################
@@ -1566,6 +1573,25 @@ function get_logs() {
 # YAML fragment generation
 ################################################################
 
+function default_security_context_content() {
+    cat <<'EOF'
+allowPrivilegeEscalation: False
+capabilities:
+  drop:
+  - ALL
+runAsNonRoot: True
+seccompProfile:
+  type: RuntimeDefault
+EOF
+}
+
+function default_security_context() {
+    cat <<EOF
+securityContext:
+$(indent 2 default_security_context_content)
+EOF
+}
+
 function _indent() {
     local -i column="$1"
     local line
@@ -2168,10 +2194,13 @@ function create_namespace() {
     local OPTIND=0
     local force=
     local opt=
-    while getopts 'f' opt "$@" ; do
+    local policy
+    policy=$(namespace_policy)
+    while getopts 'fp:' opt "$@" ; do
 	case "$opt" in
-	    f) force=-f ;;
-	    *)          ;;
+	    f) force=-f		;;
+	    p) policy="$OPTARG" ;;
+	    *)			;;
 	esac
     done
     shift $((OPTIND-1))
@@ -2183,6 +2212,9 @@ kind: Namespace
 metadata:
   name: "${namespace}"
 $(indent 2 standard_labels_yaml -t namespace)
+    pod-security.kubernetes.io/enforce: $policy
+    pod-security.kubernetes.io/audit: $policy
+    pod-security.kubernetes.io/warn: $policy
 EOF
     fi
 }
@@ -2429,12 +2461,13 @@ function create_standard_deployment() {
     local affinity_yaml=
     local workload="$requested_workload"
     local opt
-    local security_context=
+    local security_context
     local allow_replica_controller=1
     local node_class=client
     local deployment_type=$deployment_type
     local arglist_function=
     local create_container_function=create_standard_containers
+    security_context="$(default_security_context)"
     while getopts 'A:w:S:pc:d:e:C:a:' opt "$@" ; do
 	case "$opt" in
 	    A) affinity_yaml="$OPTARG"		   ;;
@@ -2512,6 +2545,14 @@ $(indent 2 standard_labels_yaml 'sync' "$namespace")
     matchLabels:
       app: ${namespace}
 $(create_container_function=create_container_sync create_spec -P -c sync -r '' "$namespace" 0 0 "$@")
+  securityContext:
+    allowPrivilegeEscalation: False
+    capabilities:
+      drop:
+      - ALL
+    runAsNonRoot: True
+    seccompProfile:
+      type: RuntimeDefault
   restartPolicy: Never
 EOF
 }
@@ -2523,7 +2564,7 @@ function create_container_drop_cache() {
     local sync_ns_port_num=
     IFS=: read -r sync_service sync_port_num sync_ns_port_num <<< "$(get_sync)"
     cat <<EOF
-- name: ${namespace}
+- name: ${namespace}-dc
   image_pull_policy: $image_pull_policy
   image: "$container_image"
   securityContext:
@@ -2572,7 +2613,9 @@ $(indent 2 standard_labels_yaml -s dc "$workload" "$namespace" "$instance" "$rep
     matchLabels:
       replica: ${namespace}-${workload}-${instance}-${replica}
   securityContext:
-    privileged: true
+    seccompProfile: RuntimeDefault
+    privileged: True
+    allowPrivilegeEscalation: False
 $(create_container_function=create_container_drop_cache create_spec -P -c drop-cache -r '' "$namespace" "$instance" 0)
   - name: "proc-sys-vm"
     hostPath:
@@ -2973,7 +3016,7 @@ function run_clusterbuster_2() {
     allocate_namespaces || return 1
     find_first_deployment || return 1
     if [[ -n "$sync_namespace" ]] ; then
-	create_namespace -f "$sync_namespace" || return 1
+	create_namespace -f -p restricted "$sync_namespace" || return 1
     fi
     create_all_objects namespaces || return 1
     if get_sync -q ; then

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -119,6 +119,10 @@ function files_process_options() {
     fi
 }
 
+function files_namespace_policy() {
+    echo privileged
+}
+
 function files_supports_reporting() {
     :
 }

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -265,4 +265,8 @@ function fio_report_options() {
 EOF
 }
 
+function fio_namespace_policy() {
+    echo privileged
+}
+
 register_workload fio

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -35,6 +35,7 @@ function _server_create_security_context() {
     if [[ -z "$___server_interface_pod" ]] ; then
 	cat <<EOF
 securityContext:
+$(indent 2 default_security_context_content)
   sysctls:
   - name: net.ipv4.ip_local_port_range
     value: $___server_port $((___server_port + ___server_port_addrs))

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -39,6 +39,7 @@ function _uperf_create_security_context() {
     if [[ -z "$___uperf_interface_pod" ]] ; then
 	cat <<EOF
 securityContext:
+$(indent 2 default_security_context_content)
   sysctls:
   - name: net.ipv4.ip_local_port_range
     value: $___uperf_port $((___uperf_port + ___uperf_port_addrs))


### PR DESCRIPTION
- Reduce privilege requirements to the extent practicable
- Create namespaces with correct security policy declarations

This will not be sufficient for everything when the default policy becomes restricted.