### PR TITLE
Allow installing Kata to a subset of nodes

### DIFF
--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -62,6 +62,10 @@ declare local_toolsdir=
 declare install_device=sda
 declare -a fixed_infra_nodes=()
 declare -i install_retries=2	# Many bare metal nodes take a long time to POST
+declare -ra commands_not_requiring_config_file=(install_cnv install_kata)
+declare -i require_config_file=1
+declare kata_install_label=
+declare kata_config_name=example-kataconfig
 platform=$(uname -i)
 
 # shellcheck disable=SC2155
@@ -1169,22 +1173,44 @@ function generate_kata_operator_yaml() {
     generate_operator_yaml "sandboxed-containers-operator"
 }
 
-function install_kata_internal() {
-    (( do_install_kata <= 0 )) && return
-    if oc get kataconfig example-kataconfig >/dev/null 2>&1 ; then
-	echo '*** Kata already installed'
-    fi
-    echo '*** Installing Kata'
-    oc apply -f - <<< "$(generate_kata_operator_yaml)"
-    # Wait for kataconfig to exist as a CRD.
-    # Probably should have a timeout here.
-    until oc get kataconfig -A >/dev/null 2>&1 ; do sleep 1; done
-    until oc apply -f - <<'EOF'
+function generate_kata_yaml() {
+    cat <<EOF
 apiVersion: kataconfiguration.openshift.io/v1
 kind: KataConfig
 metadata:
-  name: example-kataconfig
+  name: $kata_config_name
 EOF
+    if [[ -n "$kata_install_label" ]] ; then
+	local label=$kata_install_label
+	if [[ $label = *'='* ]] ; then
+	    :
+	elif [[ $label = *'/'* ]] ; then
+	    label="${label}="
+	else
+	    label="node-role.kubernetes.io/${label}="
+	fi
+	local value=${label#*=}
+	label=${label%%=*}
+	cat << EOF
+spec:
+  kataConfigPoolSelector:
+    matchLabels:
+      $label: '$value'
+EOF
+    fi
+}
+
+function install_kata_internal() {
+    (( do_install_kata <= 0 )) && return
+    if oc get kataconfig "$kata_config_name" >/dev/null 2>&1 ; then
+	echo '*** Kata already installed'
+    fi
+    echo '*** Installing Kata'
+    oc apply -f - < <(generate_kata_operator_yaml)
+    # Wait for kataconfig to exist as a CRD.
+    # Probably should have a timeout here.
+    until oc get kataconfig -A >/dev/null 2>&1 ; do sleep 1; done
+    until oc apply -f - < <(generate_kata_yaml)
     do
 	sleep 5
     done
@@ -1207,13 +1233,14 @@ EOF
 	    sleep 5
 	    continue
 	}
+	totalCount=$(oc get kataconfig example-kataconfig -ojsonpath='{.status.totalNodesCount}') || true
+	echo -ne "    Waiting for all nodes to become ready (${readyCount:-0} / $totalCount)...\r"
 	if [[ -n $readyCount && $readyCount -ne $lastCount ]] ; then
-	    echo "    Waiting for all nodes to become ready ($readyCount / $totalCount)..."
 	    lastCount=$readyCount
 	fi
 	sleep 5
     done
-    echo "    Done"
+    echo -e "\n    Done"
     echo '*** Kata installed successfully'
     if (( apply_kata_workaround )) ; then
 	# shellcheck disable=SC2155
@@ -1459,17 +1486,25 @@ if [[ ${command##*/} = ocp4-upi-util ]] ; then
     shift
 fi
 
+for cmd in "${commands_not_requiring_config_file[@]}" ; do
+    if [[ $command = "$cmd" ]] ; then
+	require_config_file=0
+	break
+    fi
+done
+
 if [[ -z "${config_file:-}" ]] ; then
     # shellcheck disable=SC2016
-    fatal 'Config file must be specified, either with -c or $OCP4_CONFIG_FILE'
+    if ((require_config_file)) ; then
+	fatal 'Config file must be specified, either with -c or $OCP4_CONFIG_FILE'
+    fi
+else
+    if [[ ! -r "$config_file" ]] ; then
+	fatal "Cannot read config file $config_file"
+    fi
+    # shellcheck disable=SC1090
+    . "$config_file" || fatal "Unable to process config file $config_file"
 fi
-
-if [[ ! -r "$config_file" ]] ; then
-    fatal "Cannot read config file $config_file"
-fi
-
-# shellcheck disable=SC1090
-. "$config_file" || fatal "Unable to process config file $config_file"
 
 declare var=
 for var in "${cmdline_vars[@]}" ; do
@@ -1496,26 +1531,31 @@ function check_macaddr() {
     done
 }
 
-(( ${#mgmt_masters[@]} == 1 || ${#mgmt_masters[@]} == 3 )) || fatal "Configuration must have 1 or 3 masters, actual ${#mgmt_masters[@]}"
-(( ${#mgmt_masters[@]} == ${#master_macs[@]} )) || fatal "Configuration must have same number of mgmt_masters as master_macs"
-(( infra_count == 0 || ${#worker_macs[@]} > infra_count )) || fatal "Configuration must have at least 1 worker_macs in addition to infra nodes"
-(( ${#worker_macs[@]} == ${#mgmt_workers[@]} )) || fatal "Configuration must have as many worker_macs as mgmt_workers, actual ${#worker_macs[@]} and ${#mgmt_workers[@]}"
-bootstrap_mac=${bootstrap_mac,,}
-master_macs=("${master_macs[@],,}")
-worker_macs=("${worker_macs[@],,}")
-check_macaddr "$bootstrap_mac"
-check_macaddr "${master_macs[@]}"
-check_macaddr "${worker_macs[@]}"
-[[ -n "$public_interface" ]] || fatal "public_interface must be specified"
-[[ -n "$bare_metal_interface" ]] || fatal "bare_metal_interface must be specified"
-[[ -n "$cluster_domain" ]] || fatal "cluster_domain must be specified"
-[[ -n "$IPMI_USER" ]] || warning "IPMI_USER is not specified; IPMI may not work correctly."
-[[ -n "$IPMI_PASSWORD" ]] || fatal "IPMI_PASSWORD is not specified; IPMI may not work correctly."
+if ((require_config_file)) ; then
+    (( ${#mgmt_masters[@]} == 1 || ${#mgmt_masters[@]} == 3 )) || fatal "Configuration must have 1 or 3 masters, actual ${#mgmt_masters[@]}"
+    (( ${#mgmt_masters[@]} == ${#master_macs[@]} )) || fatal "Configuration must have same number of mgmt_masters as master_macs"
+    (( infra_count == 0 || ${#worker_macs[@]} > infra_count )) || fatal "Configuration must have at least 1 worker_macs in addition to infra nodes"
+    (( ${#worker_macs[@]} == ${#mgmt_workers[@]} )) || fatal "Configuration must have as many worker_macs as mgmt_workers, actual ${#worker_macs[@]} and ${#mgmt_workers[@]}"
+    bootstrap_mac=${bootstrap_mac,,}
+    master_macs=("${master_macs[@],,}")
+    worker_macs=("${worker_macs[@],,}")
+    check_macaddr "$bootstrap_mac"
+    check_macaddr "${master_macs[@]}"
+    check_macaddr "${worker_macs[@]}"
+    [[ -n "$public_interface" ]] || fatal "public_interface must be specified"
+    [[ -n "$bare_metal_interface" ]] || fatal "bare_metal_interface must be specified"
+    [[ -n "$cluster_domain" ]] || fatal "cluster_domain must be specified"
+    [[ -n "$IPMI_USER" ]] || warning "IPMI_USER is not specified; IPMI may not work correctly."
+    [[ -n "$IPMI_PASSWORD" ]] || fatal "IPMI_PASSWORD is not specified; IPMI may not work correctly."
 
-[[ -r "$ocp4_pull_secret" ]] || fatal "No pull secret!"
-[[ -r "$ocp4_public_key" ]] || fatal "No public key!"
+    [[ -r "$ocp4_pull_secret" ]] || fatal "No pull secret!"
+    [[ -r "$ocp4_public_key" ]] || fatal "No public key!"
+fi
 
 for cmd in "${simple_commands[@]}" ; do
-    if [[ $command = "$cmd" ]] ; then "$command" "$@"; exit $?; fi
+    if [[ $command = "$cmd" ]] ; then
+	"$command" "$@"
+	exit $?
+    fi
 done
 fatal "Unknown command $command!"


### PR DESCRIPTION
- Allow Kata installation to a subset of nodes by label.
- Don't require a configuration file for commands that don't intrinsically need one (kata/cnv install).