### PR TITLE
Minor fixes

### DIFF
--- a/examples/clusterbuster/memory
+++ b/examples/clusterbuster/memory
@@ -9,4 +9,4 @@ no-report-object-creation
 replicas=8
 processes=3
 namespaces=1
-memorysize=1Gi
+memorysize=512Mi

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -190,7 +190,7 @@ function server_supports_reporting() {
 function server_report_options() {
     cat <<EOF
 "msg_size": $___msg_size,
-"interface": "${___server_interface}"
+"interface": "${___server_interface}",
 "server_interface": "${___server_interface_server}",
 "client_interface": "${___server_interface_client}"
 EOF


### PR DESCRIPTION
- Fix memory example size so it doesn't blow out default Kata pod size
- Fix server workload reporting