### PR TITLE
Ci miscellaneous fixes

### DIFF
--- a/CI/run-kata-perf-suite
+++ b/CI/run-kata-perf-suite
@@ -310,9 +310,9 @@ function splitarg() {
 function get_available_nodes() {
     local -a nodes
     local role
-    for role in 'node-role.kubernetes.io/clusterbuster=' 'node-role.kubernetes.io/worker=,node-role.kubernetes.io/master!=' 'node-role.kubernetes.io/worker=' ; do
+    for role in 'node-role.kubernetes.io/clusterbuster=' 'node-role.kubernetes.io/worker=,node-role.kubernetes.io/master!=,node-role.kubernetes.io/infra!=' 'node-role.kubernetes.io/worker=' ; do
 	readarray -d ' ' -t nodes < <("${OC}" get node -l "$role" -o jsonpath='{.items[*].metadata.name}')
-	if ((${#nodes[@]} >= 2)) ; then
+	if ((${#nodes[@]} >= 1)) ; then
 	    echo "${nodes[*]}"
 	    return
 	fi
@@ -324,7 +324,8 @@ function set_pin_nodes() {
     if ((! pin_jobs)) ; then return; fi
     if [[ -z "$client_pin_node" || -z "$server_pin_node" || -z "$sync_pin_node" ]] ; then
 	local -a nodes
-	readarray -d ' ' -t nodes < <(get_available_nodes)
+	readarray -d ' ' -t nodes <<< "$(get_available_nodes)"
+	nodes=("${nodes[@]//$'\n'/}")
 	local -i node_count=${#nodes[@]}
 	if ((node_count < 1)) ; then
 	    finis "No nodes found!"

--- a/clusterbuster
+++ b/clusterbuster
@@ -153,7 +153,7 @@ declare -i liveness_probe_frequency=0
 declare -i liveness_probe_sleep_time=0
 declare -i metrics_support=-1
 declare pod_prefix=
-declare -r arch=$(uname -m)
+declare arch=
 declare failure_status=Fail
 
 declare -r sync_flag_file="/tmp/syncfile";
@@ -165,7 +165,7 @@ declare xuuid=$uuid
 
 declare kata_runtime_class=kata
 declare image_pull_policy=
-declare container_image=quay.io/rkrawitz/clusterbuster:${arch}-latest
+declare container_image=
 
 declare accumulateddata=
 declare -a plurals=('s' '')
@@ -289,6 +289,11 @@ EOF
                         generate a random-based UUID.
        --exit_at_end    Exit upon completion of workload (-e/-E)
        --verbose        Print verbose log messages (-v)
+       --arch=<architecture>
+                        Use the specified architecture.  Default the
+                        architecture of this platform.
+       --containerimage=<image>
+                        Use the specified container image.
 
     Reporting Options:
        --report=<format>
@@ -659,6 +664,7 @@ function process_option() {
 	jobname)		    job_name=$optvalue				;;
 	workload)		    requested_workload=$optvalue		;;
 	basename)		    basename=$optvalue				;;
+	arch)			    arch=$optvalue				;;
 	# Object definition
 	workdir)		    common_workdir=$optvalue			;;
 	configmapfile)		    configmap_files+=("$optvalue")		;;
@@ -1408,7 +1414,7 @@ function _report_runtime_classes() {
 function _extract_metrics() {
     if supports_metrics && [[ -r "$metrics_file" ]] ; then
 	cat <<EOF
-"metrics": $("${__topdir__}/prom-extract" --define "namespace_re=${basename}-.*" -m "$metrics_file" --metrics-only --start_time="$prometheus_starting_timestamp" --epoch="$metrics_epoch" --post-settling-time=0)
+"metrics": $("${__topdir__}/prom-extract" --define "namespace_re=${basename}-.*" -m "$metrics_file" --metrics-only --start_time="$prometheus_starting_timestamp" --epoch="$metrics_epoch" --post-settling-time=0),
 EOF
     fi
 }
@@ -1518,7 +1524,7 @@ $(indent 8 call_api -w "$requested_workload" "report_options")
     }
   }
 },
-$(indent 2 _extract_metrics),
+$(indent 2 _extract_metrics)
 "nodes": $(__OC get nodes -ojson),
 "api_objects": $(__OC get all -A -l "${basename}-id=$uuid" -ojson |jq -r .items?),
 "csvs": $(__OC get csv -A -ojson | jq -r '[foreach .items[]? as $item ([[],[]];0; {name: $item.metadata.name, namespace: $item.metadata.namespace, version: $item.spec.version})]')
@@ -2557,6 +2563,7 @@ EOF
 
 function create_sync_deployment() {
     local namespace=$1; shift
+    local -a tolerations=('node-role.kubernetes.io/infra:Equal:NoSchedule' "${tolerations[@]}")
     create_object -t Pod -n "$namespace" "${namespace}-sync" <<EOF
 apiVersion: v1
 kind: Pod
@@ -3130,6 +3137,8 @@ fi
 
 iworkload=$requested_workload
 requested_workload=$(get_workload "$requested_workload") || help_extended "(Unknown workload '$iworkload')"
+arch=${arch:-$(uname -m)}
+container_image=${container_image:-quay.io/rkrawitz/clusterbuster:${arch}-latest}
 
 call_api -w "$requested_workload" -s "process_options" "${unknown_opts[@]}" || help "${unknown_opt_names[@]}"
 

--- a/clusterbuster
+++ b/clusterbuster
@@ -1008,27 +1008,6 @@ function set_start_timestamps() {
 }
 
 function get_pod_and_local_timestamps() {
-    local status
-    local -i retrycount=24
-    # Try for up to 2 minutes to get the sync pod.  If a pod is not running,
-    # attempting to oc exec into it can lock up.  Hopefully if it's running_pods
-    # it will stay OK.
-    while ((retrycount-- > 0)) ; do
-	status=$(__OC get pod "$@" -o jsonpath="{.status.phase}" 2>/dev/null)
-	case "${status,,}" in
-	    running)
-		break
-		;;
-	    error|failed)
-		echo "Sync pod failed to start:" 1>&2
-		__OC logs "$@" | tail -10 1>&2
-		killthemall "Sync pod failed"
-		;;
-	    *)
-		sleep 5
-		;;
-	esac
-    done
     until __OC exec "$@" -- /bin/sh -c "date +%s.%N" </dev/null >/dev/null 2>/dev/null ; do
 	local status
 	status=$(__OC get pod "$@" -o jsonpath="{.status.phase}" 2>/dev/null)

--- a/clusterbuster
+++ b/clusterbuster
@@ -1172,7 +1172,7 @@ function _monitor_pods() {
 	    if [[ -n "${starting_pods[*]}" ]] ; then
 		pods_now_pending=$(IFS=$'\n'; echo "${!starting_pods[*]}" | sort)
 		if [[ "$pods_now_pending" != "$pods_pending" ]] ; then
-		    pod_progress_timeout=$((timestamp+60))
+		    pod_progress_timeout=$((timestamp+10))
 		    pods_pending="$pods_now_pending"
 		else
 		    if ((timestamp > pod_progress_timeout)) ; then
@@ -1558,7 +1558,6 @@ function _get_logs() {
     tfile1=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs1.XXXXXXXXXX') || fatal "Cannot create temporary file"
     tfile2=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs2.XXXXXXXXXX') || fatal "Cannot create temporary file"
     "$@" > "$tfile1" && status=Success
-    set -x
     cat > "$tfile2" <<EOF
 {
 $(indent 2 < "$tfile1"),
@@ -2706,18 +2705,22 @@ function find_first_deployment() {
 
 function create_all_namespaces() {
     local i
+    local -a pids=()
     for i in $(seq 0 "$((parallel_namespaces - 1))") ; do
 	create_objects_n namespace "$parallel_namespaces" "$objs_per_call_namespaces" "$i" "$sleep_between_namespaces" &
+	pids+=("$!")
     done
-    wait || killthemall "Unable to create namespaces"
+    wait "${pids[@]}" || killthemall "Unable to create namespaces"
 }
 
 function create_all_secrets() {
     local i
+    local -a pids=()
     for i in $(seq 0 "$((parallel_secrets - 1))") ; do
 	create_objects_n secrets "$parallel_secrets" "$objs_per_call_secrets" "$i" "$sleep_between_secrets" "$deps_per_namespace" "$secrets" &
+	pids+=("$!")
     done
-    wait || killthemall "Unable to create secrets"
+    wait "${pids[@]}" || killthemall "Unable to create secrets"
 }
 
 function create_system_configmap() {
@@ -2729,8 +2732,9 @@ function create_system_configmap() {
 	fi
 	for i in $(seq 0 "$((parallel_configmaps - 1))") ; do
 	    create_objects_n configmaps "$parallel_configmaps" "$objs_per_call_configmaps" "$i" "$sleep_between_configmaps" "systemconfigmap" "${systemfiles[@]}"&
+	    pids+=("$!")
 	done
-	wait || killthemall "Unable to create system configmap"
+	wait "${pids[@]}" || killthemall "Unable to create system configmap"
     fi
 }
 
@@ -2738,10 +2742,12 @@ function create_all_configmaps() {
     create_system_configmap
     (( ${#configmap_files[@]} )) || return;
     local i
+    local -a pids=()
     for i in $(seq 0 "$((parallel_configmaps - 1))") ; do
 	create_objects_n configmaps "$parallel_configmaps" "$objs_per_call_configmaps" "$i" "$sleep_between_configmaps" "configmap" "${configmap_files[@]}"&
+	pids+=("$!")
     done
-    wait || killthemall "Unable to create configmaps"
+    wait "${pids[@]}" || killthemall "Unable to create configmaps"
 }
 
 function drop_host_caches() {
@@ -2757,19 +2763,23 @@ function drop_host_caches() {
     else
 	readarray -t nodes_to_drop <<< "$(____OC get -l node-role.kubernetes.io/worker node -ojsonpath="{range .items[*]}{.metadata.name}{'\n'}{end}")"
     fi
+    local -a pids=()
     for n in "${nodes_to_drop[@]}" ; do
 	((report_object_creation)) && echo "Dropping buffer cache: $n"
 	_OC debug --no-tty=true "node/$n" -- chroot /host sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches' 2>/dev/null &
+	pids+=("$!")
     done
-    wait
+    wait "${pids[@]}"
 }
 
 function create_all_deployments() {
     local i
+    local -a pids=()
     for i in $(seq 0 "$((parallel_deployments - 1))") ; do
 	create_objects_n deployment "$parallel_deployments" "$objs_per_call_deployments" "$i" "$sleep_between_deployments" "$deps_per_namespace" "$secrets" "$replicas" "$containers_per_pod" &
+	pids+=("$!")
     done
-    wait || killthemall "Unable to create deployments"
+    wait "${pids[@]}" || killthemall "Unable to create deployments"
 }
 
 function create_all_objects() {
@@ -2915,7 +2925,8 @@ function do_logging() {
     local -i logs_expected=0
     logs_expected="$(calculate_logs_required "$namespaces" "$deps_per_namespace" "$replicas" "$containers_per_pod")"
     ((logs_expected > 0)) || return 0
-    trap 'wait; return 1' TERM
+    local -i get_logs_pid=0
+    trap 'if ((get_logs_pid > 1)) ; then kill -TERM "$get_logs_pid"; wait "$get_logs_pid" 2>/dev/null; fi; return 1' TERM
 
     local -a sync_pods=()
     local namespace
@@ -2934,7 +2945,7 @@ function do_logging() {
 	fi
     done <<< "$(____OC get pod -A --no-headers -l "${basename}-sync=${uuid}")"
     get_logs "${sync_pods[@]}" &
-    local -i get_logs_pid=$!
+    get_logs_pid=$!
     if ((timeout > 0)) ; then
 	local -i itimeout=$timeout
 	local -i finis=0
@@ -3023,7 +3034,7 @@ function run_clusterbuster_2() {
 	do_cleanup -p 1>&2 || return 1
     fi
     if ((cleanup_always)) ; then
-	trap 'echo "Cleaning up" 1>&2; remove_tmpdir; doit=1; do_cleanup -f; killthemall ''; wait; remove_tmpdir; doit=1; do_cleanup -f; exit 1' TERM INT HUP
+	trap 'echo "Cleaning up" 1>&2; remove_tmpdir; doit=1; do_cleanup -f; killthemall ""; wait; remove_tmpdir; doit=1; do_cleanup -f; exit 1' TERM INT HUP
     else
 	trap 'remove_tmpdir; killthemall "Not cleaning up"; wait; exit 1' TERM HUP INT
     fi

--- a/clusterbuster
+++ b/clusterbuster
@@ -1558,6 +1558,7 @@ function _get_logs() {
     tfile1=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs1.XXXXXXXXXX') || fatal "Cannot create temporary file"
     tfile2=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs2.XXXXXXXXXX') || fatal "Cannot create temporary file"
     "$@" > "$tfile1" && status=Success
+    set -x
     cat > "$tfile2" <<EOF
 {
 $(indent 2 < "$tfile1"),
@@ -1590,7 +1591,7 @@ function _retrieve_artifacts() {
 }
 
 function print_report() {
-    if [[ $report_format == raw ]] ; then
+    if [[ $report_format = raw ]] ; then
 	cat
     else
 	"${pathdir:-.}/clusterbuster-report" ${report_format:+-o "$report_format"}

--- a/clusterbuster
+++ b/clusterbuster
@@ -1172,7 +1172,7 @@ function _monitor_pods() {
 	    if [[ -n "${starting_pods[*]}" ]] ; then
 		pods_now_pending=$(IFS=$'\n'; echo "${!starting_pods[*]}" | sort)
 		if [[ "$pods_now_pending" != "$pods_pending" ]] ; then
-		    pod_progress_timeout=$((timestamp+10))
+		    pod_progress_timeout=$((timestamp+60))
 		    pods_pending="$pods_now_pending"
 		else
 		    if ((timestamp > pod_progress_timeout)) ; then

--- a/clusterbuster
+++ b/clusterbuster
@@ -1008,6 +1008,27 @@ function set_start_timestamps() {
 }
 
 function get_pod_and_local_timestamps() {
+    local status
+    local -i retrycount=24
+    # Try for up to 2 minutes to get the sync pod.  If a pod is not running,
+    # attempting to oc exec into it can lock up.  Hopefully if it's running_pods
+    # it will stay OK.
+    while ((retrycount-- > 0)) ; do
+	status=$(__OC get pod "$@" -o jsonpath="{.status.phase}" 2>/dev/null)
+	case "${status,,}" in
+	    running)
+		break
+		;;
+	    error|failed)
+		echo "Sync pod failed to start:" 1>&2
+		__OC logs "$@" | tail -10 1>&2
+		killthemall "Sync pod failed"
+		;;
+	    *)
+		sleep 5
+		;;
+	esac
+    done
     until __OC exec "$@" -- /bin/sh -c "date +%s.%N" </dev/null >/dev/null 2>/dev/null ; do
 	local status
 	status=$(__OC get pod "$@" -o jsonpath="{.status.phase}" 2>/dev/null)
@@ -1114,6 +1135,7 @@ function _monitor_pods() {
 	warn "*** Injecting pending error"
 	starting_pods["TEST/TEST"]=1
     fi
+    local -i message_printed=0
     while read -r namespace name status ; do
 	if [[ -n "${cb_tempdir:-}" && -f "$cb_tempdir/___run_complete" ]] ; then
 	    if [[ -z "${injected_errors[timeout]:-}" ]] ; then
@@ -1174,6 +1196,18 @@ function _monitor_pods() {
 		if [[ "$pods_now_pending" != "$pods_pending" ]] ; then
 		    pod_progress_timeout=$((timestamp+60))
 		    pods_pending="$pods_now_pending"
+		    if [[ -z "$pods_pending" ]] ; then
+			echo "All pods are running                                 " | echo_if_desired 1>&2
+		    else
+			# If we've reported pods pending, and then more pods are running,
+			# we want to overprint the old message so it doesn't look like things
+			# are stuck.  However, to avoid log clutter, we don't do this unless
+			# a pending message was previously printed.
+			if ((message_printed)) ; then
+			    echo -ne "                                                  \r" | echo_if_desired 1>&2
+			    message_printed=1
+			fi
+		    fi
 		else
 		    if ((timestamp > pod_progress_timeout)) ; then
 			killthemall "No progress with pods after 1 minute, ${#starting_pods[@]} pods still pending."
@@ -1184,6 +1218,7 @@ function _monitor_pods() {
 			if ((pod_progress_timeout-timestamp == 1)) ; then p_seconds=second; fi
 			if ((${#starting_pods[@]} == 1)) ; then p_pods=pod; fi
 			echo -ne "${#starting_pods[@]} $p_pods pending (will retry $((pod_progress_timeout-timestamp)) $p_seconds)\r" | echo_if_desired 1>&2
+			message_printed=1
 		    fi
 		fi
 	    fi
@@ -1268,7 +1303,7 @@ function _log_helper() {
     fi
     until [[ $(____OC get pod -ojsonpath='{.status.phase}' "$@" 2>/dev/null) != 'Running' ]] ; do
 	# Need to produce periodic output to stderr to prevent oc exec connection from prematurely terminating
-	____OC exec --stdin=false "$@" -- sh -c "while [[ ! -f '$sync_flag_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; cat '$sync_flag_file'" 2>/dev/null && break
+	____OC exec --stdin=false "$@" -- sh -c "while [[ ! -f '$sync_flag_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; cat '$sync_flag_file'; sleep 5; echo DONE 1>&2" 2>/dev/null && break
 	sleep 5
     done
     # Tell the pod monitor to stop.

--- a/lib/clusterbuster/CI/profiles/release.profile
+++ b/lib/clusterbuster/CI/profiles/release.profile
@@ -27,6 +27,7 @@ fio-memsize=4096
 uperf-timeout=300
 
 cpusoaker-timeout=600
+cpusoaker-initial-replicas=1,2,3,4
 
 job_runtime=60
 artifactdir=

--- a/lib/clusterbuster/CI/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.workload
@@ -22,7 +22,6 @@ declare -gi ___cpusoaker_job_timeout=0
 declare -ga ___cpusoaker_initial_replicas=()
 
 function cpusoaker_next_replica_count() {
-    echo "+${____cpusoaker_current_replica_index}" 1>&2
     if ((____cpusoaker_current_replica_index < ${#___cpusoaker_initial_replicas[@]})) ; then
 
 	replicas="${___cpusoaker_initial_replicas[$____cpusoaker_current_replica_index]}"
@@ -98,7 +97,7 @@ function cpusoaker_process_option() {
 	cpusoaker*runtime)  ___cpusoaker_job_runtime=$optvalue		;;
 	cpusoaker*timeout)  ___cpusoaker_job_timeout=$optvalue		;;
 	cpusoakermax*)      ___cpusoaker_max_replicas=$optvalue		;;
-	cpusoakerinit*)	    ___cpusoaker_initial_replicas+=($(parse_optvalues "$optvalue")) ;;
+	cpusoakerinit*)	    ___cpusoaker_initial_replicas=($(parse_optvalues "$optvalue")) ;;
 	*) 		    return 1					;;
     esac
     return 0

--- a/lib/clusterbuster/CI/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.workload
@@ -19,8 +19,26 @@ declare -gi ___cpusoaker_replica_increment=5
 declare -gi ___cpusoaker_max_replicas=-1
 declare -gi ___cpusoaker_job_runtime=0
 declare -gi ___cpusoaker_job_timeout=0
+declare -ga ___cpusoaker_initial_replicas=()
+
+function cpusoaker_next_replica_count() {
+    echo "+${____cpusoaker_current_replica_index}" 1>&2
+    if ((____cpusoaker_current_replica_index < ${#___cpusoaker_initial_replicas[@]})) ; then
+
+	replicas="${___cpusoaker_initial_replicas[$____cpusoaker_current_replica_index]}"
+	____cpusoaker_current_replica_index=$((____cpusoaker_current_replica_index + 1))
+    elif ((___cpusoaker_max_replicas == -1 || ____cpusoaker_current_replicas <= ___cpusoaker_max_replicas)) ; then
+	replicas="$____cpusoaker_current_replicas"
+	____cpusoaker_current_replicas=$((____cpusoaker_current_replicas + ___cpusoaker_replica_increment))
+    else
+	return 1
+    fi
+}
 
 function cpusoaker_test() {
+    local -i ____cpusoaker_current_replica_index=0
+    local -i ____cpusoaker_current_replicas=0
+    local -i replicas=0
     local default_job_runtime=$1
     if ((___cpusoaker_replica_increment < 1)) ; then
 	echo "Replica increment must be at least 1" 1>&2
@@ -30,10 +48,11 @@ function cpusoaker_test() {
 	___cpusoaker_job_runtime=$default_job_runtime
     fi
     ___cpusoaker_job_timeout=$(compute_timeout "$___cpusoaker_job_timeout")
-    if ((___cpusoaker_starting_replicas <= 0)) ; then
-	___cpusoaker_starting_replicas=$___cpusoaker_replica_increment
+    if ((___cpusoaker_starting_replicas > 0)) ; then
+	____cpusoaker_current_replicas=$___cpusoaker_starting_replicas
+    else
+	____cpusoaker_current_replicas=$___cpusoaker_replica_increment
     fi
-    replicas=$___cpusoaker_starting_replicas
     local -A runtimes_to_test=()
     local runtime
     for runtime in "${runtimeclasses[@]}" ; do
@@ -41,7 +60,7 @@ function cpusoaker_test() {
 	runtimes+=("$runtime")
 	runtimes_to_test[$runtime]=1
     done
-    while ((___cpusoaker_max_replicas == -1 || replicas <= ___cpusoaker_max_replicas)); do
+    while cpusoaker_next_replica_count ; do
 	for runtime in "${runtimes[@]}" ; do
 	    if [[ -n "${runtimes_to_test[$runtime]:-}" ]] ; then
 		local xruntime=$runtime
@@ -59,11 +78,10 @@ function cpusoaker_test() {
 	done
 	if [[ -n "${runtimes_to_test[*]}" ]] ; then
 	    counter=$((counter+1))
-	    replicas=$((replicas+___cpusoaker_replica_increment))
 	else
 	    break
 	fi
-	if ((debugonly)) ; then
+	if ((debugonly && counter > 10)) ; then
 	    break
 	fi
     done
@@ -78,6 +96,7 @@ function cpusoaker_process_option() {
 	cpusoaker*runtime)  ___cpusoaker_job_runtime=$optvalue		;;
 	cpusoaker*timeout)  ___cpusoaker_job_timeout=$optvalue		;;
 	cpusoakermax*)      ___cpusoaker_max_replicas=$optvalue		;;
+	cpusoakerinit*)	    ___cpusoaker_initial_replicas+=($(parse_optvalues "$optvalue")) ;;
 	*) 		    return 1					;;
     esac
     return 0
@@ -106,6 +125,9 @@ function cpusoaker_help_options() {
         --cpusoaker-max-replicas=n
                                 Maximum number of replicas to scale to.
                                 Default is -1, equivalent to no upper limit.
+        --cpusoaker_initial_replicas=n[,n...]
+                                Run the specified number of replicas before starting
+                                the increment loop
 EOF
 }
 

--- a/lib/clusterbuster/pod_files/sync.py
+++ b/lib/clusterbuster/pod_files/sync.py
@@ -433,7 +433,7 @@ result['worker_results'] = data
 
 try:
     with open(tmp_sync_file_base, 'w') as tmp:
-        tmp.write(json.dumps(timebase._clean_numbers(result), sort_keys=True))
+        tmp.write(json.dumps(timebase._clean_numbers(result), sort_keys=True, indent=1))
 except Exception as exc:
     fatal(f"Can't write to sync file {tmp_sync_file_base}: {exc}")
 try:

--- a/prom-extract
+++ b/prom-extract
@@ -15,20 +15,24 @@
 # limitations under the License.
 
 from __future__ import print_function
-from prometheus_api_client import PrometheusConnect
-import argparse
-from datetime import datetime, timezone, timedelta
-from jinja2 import Template
-import json
-import openshift
-import selectors
-import subprocess
 import sys
 import time
+import os
+from datetime import datetime, timezone, timedelta
+import json
+import subprocess
 import urllib3
 import uuid
 import yaml
-import os
+try:
+    from prometheus_api_client import PrometheusConnect
+    import argparse
+    from jinja2 import Template
+    import openshift
+    import selectors
+except Exception:
+    print("{}")
+    sys.exit(1)
 
 
 def eprint(*args, **kwargs):
@@ -111,7 +115,7 @@ def get_prometheus_timestamp():
             with openshift.project('openshift-monitoring'):
                 result = openshift.selector('pod/prometheus-k8s-0').object().execute(['date', '+%s.%N'],
                                                                                      container_name='prometheus')
-                return(datetime.utcfromtimestamp(float(result.out())))
+                return datetime.utcfromtimestamp(float(result.out()))
         except Exception as err:
             if retries <= 0:
                 efail("Unable to retrieve date: %s" % err)


### PR DESCRIPTION
* Try to prevent excessively long lines of JSON output, which the shell can't handle.
* Allow specifying architecture and container image.  Architecture defaults to that of the run host, but can be changed.
* Sync pod tolerates running on infra node
* Correctly handle only a single available pin node
* run-kata-perf-suite should not use infra nodes as automatic pin nodes
* prom-extract sail more gracefully if any imports are missing (print an empty dictionary, so clusterbuster handles it correctly)
* Only wait for processes we care about, so we don't get into a deadlock with the stderr tee process.
* (minor feature) Add cpusoaker-initial-replicas to allow running a set of fixed replica count runs before starting with increments.
* Add 1, 2, 3, 4 as fixed replica counts to the release profile.
* Avoid divide by 0 errors in analysis.
* Calculate pod startup rate in analysis.