### PR TITLE
Report Mbits/sec rather than MBytes/sec for networking in spreadsheet analysis

### DIFF
--- a/lib/clusterbuster/reporting/analysis/spreadsheet/uperf_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/uperf_analysis.py
@@ -27,8 +27,8 @@ class uperf_analysis(SpreadsheetAnalysis):
             {
              'var': 'rate',
              'name': 'Rate',
-             'unit': ' (MB/sec)',
-             'multiplier': .000001
+             'unit': ' (MBit/sec)',
+             'multiplier': .000008
              },
             {
              'var': 'avg_time_op',


### PR DESCRIPTION
Networking conventionally is reported in bits/sec rather than bytes/sec.