### PR TITLE
Multiple fixes to UPI installer

### DIFF
--- a/examples/ocp4-upi-util/config
+++ b/examples/ocp4-upi-util/config
@@ -1,13 +1,52 @@
 #!/bin/bash
 
-mgmt_masters=(system-1-mgmt.example.com)
-mgmt_workers=(system-2-mgmt.example.com system-3-mgmt.example.com system-4-mgmt.example.com system-5-mgmt.example.com system-6-mgmt.example.com system-7-mgmt.example.com)
-
+bootstrap_mac=52:54:00:f9:8e:41
 public_interface=enp2s0f0
 bare_metal_interface=enp1s0f1
-master_macs=(00:00:00:00:00:00)
-worker_macs=(00:00:00:00:00:01 00:00:00:00:00:02 00:00:00:00:00:03 00:00:00:00:00:04 00:00:00:00:00:05 00:00:00:00:00:06)
-exclude_ifs=(enp1s0f1 enp2s0f1 enp3s0f0 enp3s0f1)
+
+# Other hardware interfaces that may exist that must be disabled.
+exclude_ifs=(enp2s0f1 enp3s0f1)
+
+declare -a disks=()
+# Don't rely on /dev/sdX names being stable; when
+# disks are probed asynchronously, their order can
+# change.  Instead, rely on the wwn, which is is
+# burned into the disk.
+disks[0]=/dev/disk/by-id/wwn-0x5555555555555550
+disks[1]=/dev/disk/by-id/wwn-0x5555555555555551
+disks[2]=/dev/disk/by-id/wwn-0x5555555555555552
+disks[3]=/dev/disk/by-id/wwn-0x5555555555555553
+disks[4]=/dev/disk/by-id/wwn-0x5555555555555554
+disks[5]=/dev/disk/by-id/wwn-0x5555555555555555
+
+declare -a macaddrs=()
+macaddrs[0]=00:00:00:00:00:00
+macaddrs[1]=00:00:00:00:00:01
+macaddrs[2]=00:00:00:00:00:02
+macaddrs[3]=00:00:00:00:00:03
+macaddrs[4]=00:00:00:00:00:04
+macaddrs[5]=00:00:00:00:00:05
+
+n_masters=3
+
+masters=()
+mgmt_masters=()
+master_macs=()
+mgmt_workers=()
+worker_macs=()
+for m in $(seq 0 $((n_masters - 1))) ; do
+    masters+=("node-${m}.example.com")
+    mgmt_masters+=("node-${m}-mm.example.com")
+    mac=${emacaddrs[$m]}
+    master_macs+=("$mac")
+    install_disks[$mac]=${disks[$m]}
+done
+for m in $(seq $n_masters $((${#disks[@]} - 1))) ; do
+    mgmt_workers+=("node-${m}-mm.example.com")
+    mac=${macaddrs[$m]}
+    worker_macs+=("$mac")
+    install_disks[$mac]=${disks[$m]}
+done
 
 cluster_domain=example.myocp4.com
 do_install_cnv=0

--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -67,6 +67,7 @@ declare -i require_config_file=1
 declare kata_install_label=
 declare kata_config_name=example-kataconfig
 declare -i update_packages=1
+declare -A install_disks=()
 platform=$(uname -i)
 
 # shellcheck disable=SC2155
@@ -508,40 +509,44 @@ EOF
 
 function generate_pxelinux_cfg() {
     local node_type=${1:-master}
-    local installdev
-    if [[ $node_type = bootstrap ]] ; then
-	installdev=sda
-    else
-	installdev=$install_device
-    fi
-    shift
+    local installdev=${2:-$install_device}
+    shift 2
     cat <<EOF
 DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-installer-kernel
-    APPEND rdblacklist=megaraid_sas ip=dhcp rd.neednet=1 initrd=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-installer-initramfs.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=/dev/${installdev} coreos.inst.image_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-metal-bios.raw.gz coreos.inst.ignition_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/${node_type}.ign $*
+    APPEND rdblacklist=megaraid_sas ip=dhcp rd.neednet=1 initrd=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-installer-initramfs.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=${installdev} coreos.inst.image_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-metal-bios.raw.gz coreos.inst.ignition_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/${node_type}.ign $*
     SYSAPPEND 2
 EOF
 }
 
 function generate_grub_cfg() {
     local node_type=${1:-master}
-    local installdev
-    if [[ $node_type = bootstrap ]] ; then
-	installdev=sda
-    else
-	installdev=$install_device
-    fi
-    shift
+    local installdev=${2:-$install_device}
+    shift 2
     cat <<EOF
 set timeout=10
 menuentry 'Install CoreOS' {
-  linux rhcos-installer-kernel rdblacklist=megaraid_sas ip=dhcp coreos.inst.install_dev=/dev/${installdev} nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.image_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-metal-bios.raw.gz coreos.inst.ignition_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/${node_type}.ign $*
+  linux rhcos-installer-kernel rdblacklist=megaraid_sas ip=dhcp coreos.inst.install_dev=${installdev} nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.image_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/rhcos-metal-bios.raw.gz coreos.inst.ignition_url=http://${bootstrap_ipaddr}:${pxe_port}/ocp4-upi/${node_type}.ign $*
   initrd rhcos-installer-initramfs.img
 }
 EOF
+}
+
+function get_installdev() {
+    local node_type=${1:-master}
+    local mac=${2:-}
+    if [[ $node_type = bootstrap ]] ; then
+	installdev=sda
+    else
+	installdev=${install_disks[${mac,,}]:-$install_device}
+    fi
+    if [[ ${installdev:0:1} != '/' ]] ; then
+	installdev="/dev/$installdev"
+    fi
+    echo "$installdev"
 }
 
 function setup_tftpboot() {
@@ -555,11 +560,13 @@ function setup_tftpboot() {
 	macs+=("$arg")
     done
     local m
+    local installdev
     if [[ $platform = aarch64 ]] ; then
 	for m in "${macs[@]}" ; do
 	    local file="/var/lib/tftpboot/grub.cfg-01-${m//:/-}"
 	    echo "Configuring $m as $ntype: $file"
-	    generate_grub_cfg "$ntype" "$@" > "$file"
+	    installdev=$(get_installdev "$ntype" "$m")
+	    generate_grub_cfg "$ntype" "$installdev" "$@" > "$file"
 	done
 	cp /boot/efi/EFI/BOOT/BOOTAA64.EFI /var/lib/tftpboot
 	cp /boot/efi/EFI/redhat/grubaa64.efi /var/lib/tftpboot
@@ -569,7 +576,8 @@ function setup_tftpboot() {
 	for m in "${macs[@]}" ; do
 	    local file="/var/lib/tftpboot/pxelinux.cfg/01-${m//:/-}"
 	    echo "Configuring $m as $ntype: $file"
-	    generate_pxelinux_cfg "$ntype" "$@" > "$file"
+	    installdev=$(get_installdev "$ntype" "$m")
+	    generate_pxelinux_cfg "$ntype" "$installdev" "$@" > "$file"
 	done
 	cp -p /tftpboot/lpxelinux.0 /var/lib/tftpboot
 	cp -p /tftpboot/ldlinux.c32 /var/lib/tftpboot
@@ -894,7 +902,7 @@ EOF
     setup_tftpboot bootstrap "$bootstrap_mac" -- "$rootfs_arg"
     # Clear out old known_hosts entries so ssh doesn't choke on host
     # identification changing.
-    sed -i -E -e '/^((master-|worker|infra-)[[:digit:]]+|bootstrap)[, ]/d' ~/.ssh/known_hosts
+    sed -i -E -e '/^((master|worker|infra)-[[:digit:]]+|bootstrap)[, ]/d' ~/.ssh/known_hosts
 }
 
 function ipmi_cmd() {

--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -795,7 +795,11 @@ function setup_install_1() {
 	paths[rootfs]=$(get_key "$installer_data" '.images."live-rootfs".path')
     else
 	baseURI=https://mirror.openshift.com/pub/openshift-v4/${platform}/dependencies/rhcos/$RELEASE/latest
-	echo "Using fallback $baseURI"
+	echo "Trying fallback $baseURI"
+	if ! curl -f -s "$baseURI" ; then
+	    baseURI=https://mirror.openshift.com/pub/openshift-v4/${platform}/dependencies/rhcos/pre-release/latest-$RELEASE
+	    echo "Trying fallback $baseURI"
+	fi
 	paths[bios]=rhcos-metal."${platform}".raw.gz
 	paths[kernel]=rhcos-live-kernel-"${platform}"
 	paths[initramfs]=rhcos-live-initramfs."${platform}".img
@@ -816,7 +820,11 @@ function setup_install_1() {
     fi
 
     for f in "${!fn[@]}" ; do
-	rm -f "/var/www/html/ocp4-upi/${fn[$f]}" "/var/lib/tftpboot/${fn[$f]}"
+	echo "Looking for $f (${fn[$f]}) (${paths[$f]:-})" 1>&2
+	if [[ -L "/var/www/html/ocp4-upi/${fn[$f]}" ]] ; then
+	    doit rm -f "$(readlink "/var/www/html/ocp4-upi/${fn[$f]}")"
+	fi
+	doit rm -f "/var/www/html/ocp4-upi/${fn[$f]}" "/var/lib/tftpboot/${fn[$f]}"
 	if [[ -n "${paths[$f]:-}" ]] ; then
 	    dest="/var/www/html/ocp4-upi/${paths[$f]}"
 	    if [[ ! -f "/var/www/html/ocp4-upi/${paths[$f]}" ]] ; then


### PR DESCRIPTION
- Allow specifying different disk names for each node.
- Add an additional fallback location for pre-release builds.
- Clean up old binaries linked from /var/www/html/ocp4-upi.
- Fix cleanup of old host entries
- Update example