### PR TITLE
Fetch Kata version, not just Kata operator version

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -1642,6 +1642,22 @@ EOF
     fi
 }
 
+function _get_kata_version() {
+    if [[ -n "$(____OC get kataconfig --no-headers 2>/dev/null)" ]] ; then
+	local node
+	while read -r node ; do
+	    local answer
+	    answer=$(____OC debug "$node" -- chroot /host sh -c "rpm -q --queryformat='%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}'$'\n' kata-containers" 2>/dev/null | head -1 |grep -v 'is not installed')
+	    if [[ -n "$answer" ]] ; then
+		cat <<EOF
+"kata_containers_version": "$answer",
+EOF
+		return
+	    fi
+	done <<< "$(____OC get node -oname --no-headers)"
+    fi
+}
+
 function _report_metadata_and_objects() {
     function readable_timestamp_report() {
 	local rawtime=${1:-}
@@ -1674,6 +1690,7 @@ function _report_metadata_and_objects() {
   "controller_postsync_timestamp": $second_local_ts,
   "artifact_directory": "$artifactdir",
 $(indent 2 _get_csv_version -n openshift-sandboxed-containers-operator kata)
+$(indent 2 _get_kata_version)
 $(indent 2 _get_csv_version cnv)
 $(indent 2 _get_csv_version -f .spec.labels.full_version -n openshift-storage odf)
   "options": {
@@ -2157,6 +2174,11 @@ ${objtype:+  ${basename}-x-${objtype}: "$xuuid"}
 ${logger:+  ${basename}-logger: $true}
   ${basename}-objtype: "$objtype"
 EOF
+    if [[ $objtype = worker || $objtype = sync ]] ; then
+	cat <<EOF
+  ${basename}-monitor: "$xuuid"
+EOF
+    fi
     if [[ $basename != clusterbuster ]] ; then
 	cat <<EOF
   clusterbusterbase: "true"

--- a/lib/clusterbuster/reporting/analysis/ClusterBusterAnalysis.py
+++ b/lib/clusterbuster/reporting/analysis/ClusterBusterAnalysis.py
@@ -102,7 +102,7 @@ class ClusterBusterAnalysis:
             return self.__postprocess('\n\n'.join([str(v) for v in report.values()]), status, metadata)
         elif report_type == dict or report_type == list:
             report['metadata'] = metadata
-            for v in ['uuid', 'run_host', 'openshift_version', 'kata_version', 'cnv_version']:
+            for v in ['uuid', 'run_host', 'openshift_version', 'kata_version', 'kata_containers_version', 'cnv_version']:
                 if v in metadata:
                     report['metadata'][v] = metadata[v]
             for v in ['result', 'job_start', 'job_end', 'job_runtime']:

--- a/lib/clusterbuster/reporting/analysis/ci/analyze_postprocess.py
+++ b/lib/clusterbuster/reporting/analysis/ci/analyze_postprocess.py
@@ -29,6 +29,7 @@ class AnalyzePostprocess:
             'uuid': None,
             'run_host': None,
             'openshift_version': None,
+            'kata_containers_version': None,
             'kata_version': None,
             'result': None,
             'job_start': None,
@@ -42,7 +43,7 @@ class AnalyzePostprocess:
                 elif job_status.get(var, None) is not None and job_status[var] != self._report['metadata'][var]:
                     raise Exception(f'Mismatched {var} in status ({job_status[var]} vs {self._report["metadata"][var]}!')
         for job, job_metadata in self._metadata['jobs'].items():
-            for var in ['uuid', 'run_host', 'openshift_version', 'kata_version']:
+            for var in ['uuid', 'run_host', 'openshift_version', 'kata_containers_version', 'kata_version']:
                 if self._report['metadata'][var] is None:
                     self._report['metadata'][var] = job_metadata.get(var, None)
                 elif job_metadata.get(var, None) is not None and job_metadata[var] != self._report['metadata'][var]:

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/analyze_postprocess.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/analyze_postprocess.py
@@ -35,7 +35,7 @@ class AnalyzePostprocess:
         for job, job_metadata in self._metadata['jobs'].items():
             if job not in metadata:
                 metadata[job] = {}
-            for var in ['uuid', 'run_host', 'openshift_version', 'kata_version']:
+            for var in ['uuid', 'run_host', 'openshift_version', 'kata_containers_version', 'kata_version']:
                 if var in job_metadata:
                     metadata[job][var] = job_metadata[var]
         meta_answer = ''

--- a/lib/clusterbuster/reporting/analysis/summary/analyze_postprocess.py
+++ b/lib/clusterbuster/reporting/analysis/summary/analyze_postprocess.py
@@ -35,7 +35,7 @@ class AnalyzePostprocess:
         for job, job_metadata in self._metadata['jobs'].items():
             if job not in metadata:
                 metadata[job] = {}
-            for var in ['uuid', 'run_host', 'openshift_version', 'kata_version']:
+            for var in ['uuid', 'run_host', 'openshift_version', 'kata_containers_version', 'kata_version']:
                 if var in job_metadata:
                     metadata[job][var] = job_metadata[var]
         self._report['metadata'] = metadata

--- a/lib/clusterbuster/reporting/loader/ClusterBusterLoader.py
+++ b/lib/clusterbuster/reporting/loader/ClusterBusterLoader.py
@@ -59,6 +59,7 @@ class LoadOneReport:
             data['metadata']['jobs'][name]['server_version'] = self._metadata['kubernetes_version']['serverVersion']
             data['metadata']['jobs'][name]['openshift_version'] = self._metadata['kubernetes_version'].get('openshiftVersion', 'Unknown')
             data['metadata']['jobs'][name]['run_host'] = self._metadata['runHost']
+            data['metadata']['jobs'][name]['kata_containers_version'] = self._metadata.get('kata_containers_version', None)
             data['metadata']['jobs'][name]['kata_version'] = self._metadata.get('kata_version', None)
             data['metadata']['jobs'][name]['cnv_version'] = self._metadata.get('cnv_version', None)
         else:
@@ -74,6 +75,8 @@ class LoadOneReport:
                     raise Exception(f"Mismatched server_version: {self._metadata['kubernetes_version']['serverVersion']}, {data['metadata']['jobs'][name]['server_version']}")
                 if self._metadata.get('kata_version') != data['metadata']['jobs'][name]['kata_version']:
                     raise Exception(f"Mismatched kata_version: {self._metadata.get('kata_version')}, {data['metadata']['jobs'][name]['kata_version']}")
+                if self._metadata.get('kata_containers_version') != data['metadata']['jobs'][name]['kata_containers_version']:
+                    raise Exception(f"Mismatched kata_containers_version: {self._metadata.get('kata_containers_version')}, {data['metadata']['jobs'][name]['kata_containers_version']}")
         if self._metadata['kind'] != 'clusterbusterResults':
             raise Exception("Invalid results file")
         if 'runtime_class' in self._metadata:


### PR DESCRIPTION
The Kata Containers version is if anything more important than the Kata operator version.  Unfortunately, kata-version is already used for the operator version, so for compatibility the new item is called kata-containers-version.

Also fix a bug in the monitoring that resulted in the sync pod not being watched correctly.