### PR TITLE
Retrieve artifacts if the run fails or times out

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -1248,7 +1248,8 @@ function run_status_monitor() {
     (while : ; do sleep 1; printf '++Mark++ ++Mark+ %(%s)T%s' -1 $'\n'; done &)
     if [[ -n "$artifactdir" ]] ; then
 	mkdir -p "$artifactdir"
-	run_status_monitor_1 "$@" | tee >(grep -v '\+\+Mark\+\+' | timestamp > "${artifactdir}/monitor.log")
+	rm -f "$artifactdir/.artifacts"
+	run_status_monitor_1 "$@" | tee >(timestamp > "${artifactdir}/monitor.log")
     else
 	run_status_monitor_1 "$@"
     fi
@@ -1369,6 +1370,7 @@ function _monitor_pods() {
 		message_printed=0
 	    fi
 	    if ((timeout > 0 && timestamp > timeout)) ; then
+		retrieve_successful_logs=1 _retrieve_artifacts
 		killthemall "Monitor pods timeout!"
 	    fi
 	fi
@@ -1515,7 +1517,7 @@ function _get_logs_poll() {
 function get_logs_poll() {
     local tfile
     tfile=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs.XXXXXXXXXX') || fatal "Cannot create temporary file"
-    trap 'if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then rm -f "$tfile"; unset tfile; fi; echo "Status: Fail"; return 1' INT TERM HUP USR1
+    trap 'retrieve_successful_logs=1 _retrieve_artifacts; if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then rm -f "$tfile"; unset tfile; fi; echo "Status: Fail"; return 1' INT TERM HUP USR1
     _get_logs_poll "$*" > "$tfile"
     local status=$?
     if ((status == 0)) ; then
@@ -1751,7 +1753,7 @@ function _get_logs() {
     local -i reported=0
     local tfile1=
     local tfile2=
-    trap 'if [[ -n "$tfile2" && -f "$tfile2" ]] ; then rm -f "$tfile1" "$tfile2" ; fi; if ((! reported)) ; _report_failure; reported=1; fi; _retrieve_artifacts; return 1' TERM
+    trap 'if [[ -n "$tfile2" && -f "$tfile2" ]] ; then rm -f "$tfile1" "$tfile2" ; fi; if ((! reported)) ; _report_failure; reported=1; fi; retrieve_successful_logs=1 _retrieve_artifacts; return 1' TERM
     tfile1=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs1.XXXXXXXXXX') || fatal "Cannot create temporary file"
     tfile2=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs2.XXXXXXXXXX') || fatal "Cannot create temporary file"
     "$@" > "$tfile1" && {
@@ -1773,9 +1775,10 @@ EOF
 
 function _retrieve_artifacts() {
     local always_retrieve_artifacts=${1:-}
-    if [[ -n "$artifactdir" ]] ; then
+    if [[ -n "$artifactdir" && ! -f "$artifactdir/.artifacts" ]] ; then
 	mkdir -p "$artifactdir/Logs"
 	mkdir -p "$artifactdir/Describe"
+	touch "$artifactdir/.artifacts"
 	local -i failcount=0
 	local -A jobs_pending
 	local job
@@ -3484,6 +3487,7 @@ function do_logging() {
 	    fi
 	done
 	if (( finis <= 0 )) ; then
+	    retrieve_successful_logs=1 _retrieve_artifacts
 	    if ((finis < 0)) ; then
 		killthemall "Run failed"
 	    else


### PR DESCRIPTION
Retrieve logs and descriptions when clusterbuster run fails or times out.