### PR TITLE
Create multi-arch images

### DIFF
--- a/CI/run-kata-perf-suite
+++ b/CI/run-kata-perf-suite
@@ -394,9 +394,9 @@ function process_profile() {
 function force_pull_base_image() {
     for n in $("${OC}" get node --no-headers |awk '{print $1}') ; do
 	if ((debugonly)) ; then
-	    echo "${OC}" debug --no-stdin=true --no-tty=true node/"$n" -- chroot /host sh -c ' podman pull quay.io/rkrawitz/clusterbuster'
+	    echo "${OC}" debug --no-stdin=true --no-tty=true node/"$n" -- chroot /host sh -c ' podman pull quay.io/rkrawitz/clusterbuster:latest quay.io/rkrawitz/clusterbuster-workloads:latest'
 	else
-	    "${OC}" debug --no-stdin=true --no-tty=true node/"$n" -- chroot /host sh -c ' podman pull quay.io/rkrawitz/clusterbuster' &
+	    "${OC}" debug --no-stdin=true --no-tty=true node/"$n" -- chroot /host sh -c ' podman pull quay.io/rkrawitz/clusterbuster:latest quay.io/rkrawitz/clusterbuster-workloads:latest' &
 	fi
     done
     if ((! debugonly)) ; then

--- a/clusterbuster
+++ b/clusterbuster
@@ -3241,7 +3241,7 @@ function create_all_secrets() {
 function create_system_configmap() {
     local -a systemfiles
     readarray -t systemfiles < <(list_configmaps | grep .)
-    if [[ ${#systemfiles[@]} > 0 && $sync_start -ne 0 && -n "$sync_namespace" && $sync_in_first_namespace -eq 0 ]] ; then
+    if [[ ${#systemfiles[@]} -gt 0 && $sync_start -ne 0 && -n "$sync_namespace" && $sync_in_first_namespace -eq 0 ]] ; then
 	create_configmaps "$sync_namespace" "systemconfigmap" "${systemfiles[@]}"
     fi
     local -a userfiles
@@ -3713,7 +3713,7 @@ fi
 iworkload=$requested_workload
 requested_workload=$(get_workload "$requested_workload") || help_extended "(Unknown workload '$iworkload')"
 arch=${arch:-$(uname -m)}
-container_image=${container_image:-quay.io/rkrawitz/clusterbuster:${arch}-latest}
+container_image=${container_image:-quay.io/rkrawitz/clusterbuster:latest}
 
 call_api -w "$requested_workload" -s "process_options" "${unknown_opts[@]}" || help "${unknown_opt_names[@]}"
 

--- a/force-pull-clusterbuster-image
+++ b/force-pull-clusterbuster-image
@@ -17,7 +17,7 @@ declare OC=${OC:-${KUBECTL:-}}
 OC=${OC:-$(type -p oc)}
 OC=${OC:-$(type -p kubectl)}	# kubectl might not work, though...
 
-declare images=("quay.io/rkrawitz/clusterbuster:$(uname -m)-latest" "quay.io/rkrawitz/clusterbuster-workloads:$(uname -m)-latest")
+declare images=("quay.io/rkrawitz/clusterbuster:latest" "quay.io/rkrawitz/clusterbuster-workloads:latest")
 
 if [[ -n "$*" ]] ; then
     images=("$@")

--- a/lib/clusterbuster/container-image/Dockerfile
+++ b/lib/clusterbuster/container-image/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/fedora/fedora-minimal:latest
 
 RUN microdnf --setopt=install_weak_deps=0 install -y \
+    procps-ng \
     python3 \
     util-linux \
     && \

--- a/lib/clusterbuster/container-image/Dockerfile.workloads
+++ b/lib/clusterbuster/container-image/Dockerfile.workloads
@@ -1,5 +1,4 @@
-ARG ARCH=${ARCH}
-FROM quay.io/rkrawitz/clusterbuster:${ARCH}-latest
+FROM quay.io/rkrawitz/clusterbuster:latest
 
 USER 0
 RUN microdnf --setopt=install_weak_deps=0 install -y \

--- a/lib/clusterbuster/container-image/Makefile
+++ b/lib/clusterbuster/container-image/Makefile
@@ -1,17 +1,25 @@
-.PHONY: build push build-all push-all build-workloads push-workloads
+.PHONY: base workloads
 
-push-all: build-all push push-workloads
-build-all: build build-workloads
-ARCH=$(shell uname -m)
+all: base workloads
+workloads: base
+MANIFEST=build-clusterbuster
+MANIFEST_WORKLOADS=build-clusterbuster-workloads
+ARCHES=amd64 arm64
 
-build:
-	buildah bud --build-arg ARCH=$(ARCH) -t clusterbuster .
+ifneq ($(CB_REGISTRY_AUTH_FILE),)
+export REGISTRY_AUTH_FILE=$(CB_REGISTRY_AUTH_FILE)
+endif
 
-push: build
-	podman push localhost/clusterbuster quay.io/rkrawitz/clusterbuster:$(ARCH)-latest
+base:
+	-buildah manifest rm "$(MANIFEST)"
+	buildah manifest create "$(MANIFEST)"
+	buildah bud -t quay.io/rkrawitz/clusterbuster:latest --manifest "$(MANIFEST)" -f Dockerfile --arch amd64 .
+	buildah bud -t quay.io/rkrawitz/clusterbuster:latest --manifest "$(MANIFEST)" -f Dockerfile --arch arm64 .
+	buildah manifest push --all "$(MANIFEST)" docker://quay.io/rkrawitz/clusterbuster:latest
 
-build-workloads: push
-	buildah bud --build-arg ARCH=$(ARCH) -t clusterbuster-workloads -f Dockerfile.workloads .
-
-push-workloads: build
-	podman push localhost/clusterbuster-workloads quay.io/rkrawitz/clusterbuster-workloads:$(ARCH)-latest
+workloads:
+	-buildah manifest rm "$(MANIFEST_WORKLOADS)"
+	buildah manifest create "$(MANIFEST_WORKLOADS)"
+	buildah bud -t quay.io/rkrawitz/clusterbuster-workloads:latest --manifest "$(MANIFEST_WORKLOADS)" -f Dockerfile.workloads --arch amd64 .
+	buildah bud -t quay.io/rkrawitz/clusterbuster-workloads:latest --manifest "$(MANIFEST_WORKLOADS)" -f Dockerfile.workloads --arch arm64 .
+	buildah manifest push --all "$(MANIFEST_WORKLOADS)" docker://quay.io/rkrawitz/clusterbuster-workloads:latest

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -54,7 +54,7 @@ function fio_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:latest"
     create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -43,7 +43,7 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:latest"
     create_sync_service "$namespace" \
 			"$((containers_per_pod * processes_per_pod * replicas * count))" \
 			"$((containers_per_pod * replicas * count))"

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -97,7 +97,7 @@ function uperf_create_deployment() {
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:latest"
     create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do


### PR DESCRIPTION
- Create multi-arch images correctly rather than having separate named images.
- Install procps-ng to get the ps command.