### PR TITLE
Enable use _idname() as a deterministic random seed by using child index rather than process ID.

### DIFF
--- a/docs/clusterbuster.md
+++ b/docs/clusterbuster.md
@@ -368,7 +368,7 @@ This currently only documents the most commonly used members.
 * `clusterbuster_pod_client._idname(self, args: list = None, separator: str = ':')`
 
   Generate an identifier based on namespace, pod name, container name,
-  and process ID along with any other tokens desired by the workload.
+  and child index along with any other tokens desired by the workload.
   If a separator is provided, it is used to separate the tokens.
 
 * `clusterbuster_pod_client._podname(self)`

--- a/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
+++ b/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
@@ -72,6 +72,7 @@ class clusterbuster_pod_client(cb_util):
             self.__enable_sync = True
             self.__host_table = {}
             self.__reported_results = False
+            self.__child_idx = -1
             os.environ['__CB_SYNCHOST'] = self.__synchost
             os.environ['__CB_SYNCPORT'] = str(self.__syncport)
             os.environ['__CB_DROP_CACHE_HOST'] = self.__drop_cache_host
@@ -96,7 +97,6 @@ class clusterbuster_pod_client(cb_util):
                 if initialize_timing_if_needed:
                     self.__initialize_timing()
                 self._set_offset(self.__timing_parameters.get('local_offset_from_sync', 0))
-                self._child_idx = None
                 self.__processes = 1
                 self.__requested_ip_addresses = [f'{self.__pod}.{self.__namespace}']
             else:
@@ -133,7 +133,7 @@ class clusterbuster_pod_client(cb_util):
                     os._exit(1)
                 if child == 0:  # Child
                     self.__is_worker = True
-                    self._child_idx = i
+                    self.__child_idx = i
                     self._timestamp(f"About to run subprocess {i}")
                     try:
                         start_time = self._adjusted_time()
@@ -249,7 +249,7 @@ class clusterbuster_pod_client(cb_util):
         :param extra_components: Any extra components to be appended to the id
         :return: Identification string
         """
-        components = [self._namespace(), self._podname(), self._container(), str(os.getpid())]
+        components = [self._namespace(), self._podname(), self._container(), str(self.__child_idx)]
         if args is not None:
             components = components + [str(c) for c in args]
         return separator.join(components)


### PR DESCRIPTION
This will not work correctly for deployments or replicasets, where the podnames have random hashes appended, so those deployment types should not be used where deterministic IDs are required.

Also make child_idx private; the index is passed to each subprocess so it is not necessary that clients have direct access to this member.