### PR TITLE
Fix the name of the container image for the workloads using the -workloads image

### DIFF
--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -61,7 +61,7 @@ function fio_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
     create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -43,7 +43,7 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
     create_sync_service "$namespace" \
 			"$((containers_per_pod * processes_per_pod * replicas * count))" \
 			"$((containers_per_pod * replicas * count))"

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -97,7 +97,7 @@ function uperf_create_deployment() {
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-latest"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
     create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do


### PR DESCRIPTION
The main image was fixed much earlier.  This showed up when I deleted the :x86_64-latest tags in the quay.io repo.