### PR TITLE
Fix the name of the workloads container image

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -207,6 +207,7 @@ declare pod_prefix=
 declare arch=
 declare failure_status=Fail
 declare -i create_pods_privileged=0
+declare perf_ci_tag=perf-ci-v1.2
 
 declare -r sync_flag_file="/tmp/syncfile";
 declare -r sync_error_file="/tmp/syncerror";
@@ -3420,7 +3421,7 @@ fi
 iworkload=$requested_workload
 requested_workload=$(get_workload "$requested_workload") || help_extended "(Unknown workload '$iworkload')"
 arch=${arch:-$(uname -m)}
-container_image=${container_image:-quay.io/rkrawitz/clusterbuster:${arch}-perf-ci-v1.2}
+container_image=${container_image:-quay.io/rkrawitz/clusterbuster:${arch}-${perf_ci_tag}}
 
 call_api -w "$requested_workload" -s "process_options" "${unknown_opts[@]}" || help "${unknown_opt_names[@]}"
 

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -61,7 +61,7 @@ function fio_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-${perf_ci_tag}"
     create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -61,7 +61,7 @@ function fio_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
     create_sync_service "$namespace" "$((containers_per_pod * processes_per_pod * replicas * count))" \
 				  "$((containers_per_pod * replicas * count))"
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -43,7 +43,7 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
     create_sync_service "$namespace" \
 			"$((containers_per_pod * processes_per_pod * replicas * count))" \
 			"$((containers_per_pod * replicas * count))"

--- a/lib/clusterbuster/workloads/sysbench.workload
+++ b/lib/clusterbuster/workloads/sysbench.workload
@@ -43,7 +43,7 @@ function sysbench_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-${perf_ci_tag}"
     create_sync_service "$namespace" \
 			"$((containers_per_pod * processes_per_pod * replicas * count))" \
 			"$((containers_per_pod * replicas * count))"

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -97,7 +97,7 @@ function uperf_create_deployment() {
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
     create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -97,7 +97,7 @@ function uperf_create_deployment() {
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
-    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-perf-ci-v1.2"
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:${arch}-${perf_ci_tag}"
     create_sync_service "$namespace" "$((containers_per_pod * replicas * count))" "$(( (containers_per_pod * replicas * count) + count))"
 
     for instance in $(seq "$first_deployment" $((count + first_deployment - 1))) ; do


### PR DESCRIPTION
The main image was fixed early in the history of the kata-v1.2 branch.  This broke when I deleted the :<arch>-latest tags from the quay.io/rkrawitz/clusterbuster-workloads image.  The CI had inadvertently been using the mainline image.