### PR TITLE
Memory workload enhancements

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -214,6 +214,7 @@ declare -i wait_forever=0
 declare -a pod_labels=()
 declare -i get_logs_pid=0
 declare -a extra_args=()
+declare -i metrics_interval=30
 
 declare -r sync_flag_file="/tmp/syncfile";
 declare -r sync_error_file="/tmp/syncerror";
@@ -398,6 +399,9 @@ $(print_workloads_supporting_reporting '                        - ')
        --metrics-epoch=<seconds>
                         Number of seconds to look back for metrics prior
                         to start of run (default $metrics_epoch)
+       --metrics-interval=<interval>
+                        Interval between data points for metrics collection.
+                        Default $metrics_interval.
        --force-no-metrics
                         Do not attempt anything that would use metrics
                         or the prometheus pod.
@@ -784,6 +788,7 @@ function process_option() {
 	artifactdir)		    artifactdir="$optvalue"			;;
 	metrics|metricsfile)	    set_metrics_file "$optvalue"		;;
 	metricsepoch)		    metrics_epoch=$optvalue			;;
+	metricsinterval)	    metrics_interval=$optvalue			;;
 	reportformat)		    report_format=$optvalue			;;
 	jsonreport)		    report_format=json				;;
 	rawreport)		    report_format=raw				;;
@@ -1089,7 +1094,7 @@ function __OC() {
     elif [[ $1 = exec || $1 = rsh ]] ; then
 	# Capture error output
 	(set -o pipefail; "$OC" "$@" 2>&1 1>&3 |sed -e "s/^/${*//\//\\/}: /" |timestamp 1>&2) 3>&1
-    elif [[ $1 = describe || $1 = get || $1 = status || $1 = logs ]] ; then
+    elif [[ $1 = describe || $1 = get || $1 = status || $1 = logs || $1 = version ]] ; then
 	"$OC" "$@"
     elif ((report_object_creation)) ; then
 	"$OC" "$@" 2>&1
@@ -1312,7 +1317,7 @@ function start_prometheus_snapshot() {
     __OC wait --for=condition=Ready -n openshift-monitoring pod/prometheus-k8s-0 || killthemall "Prometheus pod did not become ready"
     set_start_timestamps || return 1
     # Wait for prometheus pod to fully initialize
-    sleep 60
+    sleep "$metrics_epoch"
     echo "Prometheus snapshot started" | echo_if_desired 1>&2
 }
 
@@ -1719,8 +1724,9 @@ function _report_runtime_classes() {
 
 function _extract_metrics() {
     if supports_metrics && [[ -r "$metrics_file" ]] ; then
+	sleep 60
 	cat <<EOF
-"metrics": $("${__topdir__}/prom-extract" --define "namespace_re=${basename}-.*" -m "$metrics_file" --metrics-only --start_time="$prometheus_starting_timestamp" --epoch="$metrics_epoch" --post-settling-time=0),
+"metrics": $("${__topdir__}/prom-extract" --define "namespace_re=${basename}-.*" -m "$metrics_file" -s "$metrics_interval" --metrics-only --start_time="$((prometheus_starting_timestamp - metrics_epoch))" --post-settling-time="$((metrics_epoch*2))"),
 EOF
     fi
 }

--- a/clusterbuster-report
+++ b/clusterbuster-report
@@ -26,21 +26,20 @@ if 'CB_LIBPATH' in os.environ:
 parser = argparse.ArgumentParser(description='Generate ClusterBuster report')
 report_formats = ClusterBusterReporter.list_report_formats()
 
-parser.add_argument('-o', '--format', '--output_format', '--output', default='summary', metavar='format', type=str,
+parser.add_argument('-o', '--format', '--output_format', '--output', '--report-format',
+                    default='summary', metavar='format', type=str,
                     choices=report_formats, help=f'Report format: one of {", ".join(report_formats)}')
 parser.add_argument('--list_formats', action='store_true', help='List available report formats')
 parser.add_argument("files", metavar='file', type=str, nargs='*', help='Files to process')
 
-args = parser.parse_args()
+args, extras = parser.parse_known_args()
 if args.list_formats:
     print('\n'.join(sorted(report_formats)))
     sys.exit(1)
 
 try:
-    ClusterBusterReporter.print_report(args.files, format=args.format)
-except KeyboardInterrupt:
-    sys.exit(1)
-except BrokenPipeError:
+    ClusterBusterReporter.print_report(args.files, report_format=args.format, extras=extras)
+except (KeyboardInterrupt, BrokenPipeError):
     sys.exit(1)
 except Exception:
     print(f"Decoding JSON failed: {traceback.format_exc()}", file=sys.stderr)

--- a/lib/clusterbuster/reporting/prettyprint.py
+++ b/lib/clusterbuster/reporting/prettyprint.py
@@ -25,7 +25,7 @@ def fformat(num: float, precision: int = 5):
             return f'{num:.{precision}f}'
         else:
             return str(round(num))
-    except Exception:
+    except TypeError:
         return str(num)
 
 
@@ -55,7 +55,7 @@ def prettyprint(num: float, precision: int = 5, integer: int = 0, base: int = No
         base = 1000
     try:
         num = float(num)
-    except Exception:
+    except ValueError:
         return str(num)
     num *= multiplier
     if integer or num == 0:
@@ -84,7 +84,7 @@ def prettyprint(num: float, precision: int = 5, integer: int = 0, base: int = No
         infix = 'i'
         base = 1024
     elif base != -10 or base != -1 or base != -1000:
-        raise Exception(f'Illegal base {base} for prettyprint; must be 1000 or 1024')
+        raise ValueError(f'Illegal base {base} for prettyprint; must be 1000 or 1024')
     if base > 0 and abs(num) >= base ** 5:
         return f'{fformat(num / (base ** 5), precision=precision)} P{infix}{suffix}'
     elif base > 0 and abs(num) >= base ** 4:

--- a/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
+++ b/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
@@ -148,9 +148,13 @@ class ClusterBusterReporter:
         elif report_format.startswith('json'):
             json.dump(answers, outfile, indent=2)
         elif report_format != "none":
-            answer = "\n\n".join([answer for answer in answers if (answer is not None and answer != '')])
-            if answer is not None and answer != '':
-                print(answer, file=outfile)
+            if report_format.startswith('parseable'):
+                delim = ''
+            else:
+                delim = '\n\n'
+            answers = [answer for answer in answers if (answer is not None and answer != '')]
+            if answers:
+                print(delim.join(answers), file=outfile)
 
     @staticmethod
     def list_report_formats():
@@ -912,12 +916,16 @@ class ClusterBusterReporter:
         return [width, integer_width]
 
     def __parseable_path(self, path: list):
-        answer = '.'.join([elt.replace(':', '') for elt in path]).lower().replace('\n', '')
+        dpath = list(os.path.split(self._jdata['metadata']['RunArtifactDir']))
+        dpath.append(self._jdata['metadata']['job_name'])
+        dpath.extend(path)
+        answer = '.'.join([elt.replace(':', '').replace('.', '_')
+                           for elt in dpath if elt not in [None, '', '.', '..']]).lower().replace('\n', '')
         for char in [' ', ',', '/', '"', "'"]:
             answer = answer.replace(char, '_')
         while '__' in answer:
             answer = answer.replace('__', '_')
-        return '.'.join([self._jdata['metadata']['job_name'], answer])
+        return answer
 
     def __indent(self, string: str, target_column: int):
         if 'parseable' in self._format:

--- a/lib/clusterbuster/reporting/reporter/cpusoaker_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/cpusoaker_reporter.py
@@ -18,8 +18,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class cpusoaker_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)
         self._add_accumulators(['work_iterations'])
         self._set_header_components(['namespace', 'pod', 'container', 'process_id'])
 

--- a/lib/clusterbuster/reporting/reporter/files_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/files_reporter.py
@@ -18,8 +18,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class files_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)
         self._file_operations = ['create', 'read', 'remove']
         self._add_timeline_vars(['create.operation', 'read.operation', 'remove.operation'])
         self._add_accumulators(['create.user_cpu_time', 'create.system_cpu_time', 'create.cpu_time', 'create.operations',

--- a/lib/clusterbuster/reporting/reporter/fio_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/fio_reporter.py
@@ -19,8 +19,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class fio_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)
         self._jobs = jdata['metadata']['workload_metadata']['jobs']
         self._job_names = list(self._jobs.keys())
         self._fio_operations = ['read', 'write', 'trim']

--- a/lib/clusterbuster/reporting/reporter/generic_nodata_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/generic_nodata_reporter.py
@@ -20,6 +20,6 @@ from .ClusterBusterReporter import ClusterBusterReporter
 class generic_nodata_reporter(ClusterBusterReporter):
     # Not necessary to override anything; we're not adding anything on
     # top of the base class.
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)
         self._expect_row_data = False

--- a/lib/clusterbuster/reporting/reporter/generic_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/generic_reporter.py
@@ -20,5 +20,5 @@ from .ClusterBusterReporter import ClusterBusterReporter
 class generic_reporter(ClusterBusterReporter):
     # Not necessary to override anything; we're not adding anything on
     # top of the base class.
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)

--- a/lib/clusterbuster/reporting/reporter/memory_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/memory_reporter.py
@@ -14,19 +14,82 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+import json
+from copy import deepcopy
+import traceback
+import sys
 from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class memory_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+
+    TIMELINE_FORMATS = ['tsv', 'csv', 'json']
+    SEPARATORS = {
+        'tsv': '\t',
+        'csv': ','
+        }
+    COLUMNS = {
+        'time': {
+            'header': 'Time',
+            'precise_format': '%.3f',
+            'format': '%.0f'
+            },
+        'current_request': {
+            'header': 'Workload Memory Request'
+            },
+        'current_in_use': {
+            'header': 'Workload Memory In Use'
+            },
+        'jobs': {
+            'header': 'Jobs'
+            },
+        'max': {
+            'header': 'Maximum Workload Request'
+            },
+        'work_rate': {
+            'header': 'Work Rate',
+            'round': 0
+            },
+        'node_in_use': {
+            'header': 'Node Memory In Use'
+            },
+        'working_set': {
+            'header': 'Cgroup Memory In Use'
+            },
+        'node_CPU': {
+            'header': 'Node CPU',
+            'format': False
+            },
+        'container_CPU': {
+            'header': 'Cgroup CPU',
+            'format': False
+            },
+        }
+
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras=extras)
+        parser = argparse.ArgumentParser(description='Parse memory report')
+        parser.add_argument('--dense-timeline', '--dense', type=float, nargs='?', const=1.0, help='Print dense timeline')
+        parser.add_argument('--precise-timeline', '--precise', action='store_true', help='Print high precision timeline')
+        parser.add_argument('--numeric-timeline', action='store_true', help='Print scannable numbers')
+        parser.add_argument('--timeline-format', type=str, choices=self.TIMELINE_FORMATS,
+                            help=f'Timeline format: one of {", ".join(self.TIMELINE_FORMATS)}',
+                            default='tsv')
+        parser.add_argument('--timeline-file', type=str, help='Output file for timeline')
+        parser.add_argument('--timeline-column', action='append', help='Column options (see the code)')
+        self.args, self.extra_args = parser.parse_known_args(extras)
+        if self.args.dense_timeline is not None:
+            if float(self.args.dense_timeline) <= 0:
+                raise ValueError('--dense-timeline must be greater than 0')
         self.work = {}
         self.work_total = 0
-        pod_node = {}
+        self.pod_node = {}
         self.start_times = {}
         self.end_times = {}
         self.net_start_time = None
         self.net_end_time = None
+        self.timeline = None
         for obj in jdata.get('api_objects', []):
             try:
                 name = f'{obj["metadata"]["name"]}.{obj["metadata"]["namespace"]}'
@@ -34,26 +97,76 @@ class memory_reporter(ClusterBusterReporter):
                     node = obj['spec']['nodeName']
                 elif obj.get('kind', None) == 'VirtualMachineInstance':
                     node = list(obj['status']['activePods'].values())[0]
-                pod_node[name] = node
+                self.pod_node[name] = node
             except KeyError:
                 pass
+        self._set_header_components(['namespace', 'pod', 'container', 'process_id'])
+        self.columns = deepcopy(self.COLUMNS)
+        if self.args.timeline_column:
+            for arg in self.args.timeline_column:
+                try:
+                    name, data = arg.split(':', 2)
+                except ValueError:
+                    continue
+                if name == '' or name == '-':
+                    continue
+                if name.startswith('-'):
+                    self.columns.pop(name, None)
+                if name not in self.columns:
+                    self.columns[name] = {}
+                for param in data.split(';'):
+                    try:
+                        key, value = param.split('=')
+                    except ValueError:
+                        pass
+                    if key.startswith('!'):
+                        value = False
+                    elif key.startswith('+'):
+                        value = True
+                    elif key.startswith('-'):
+                        self.columns[name].pop(key, None)
+                    else:
+                        self.columns[name][key] = value
+
+    def timeint(self, val: float):
+        if self.args.dense_timeline:
+            return val / self.args.dense_timeline
+        else:
+            return val
+
+    def inttime(self, val: float):
+        if self.args.dense_timeline:
+            if self.args.dense_timeline % 1:
+                return val * self.args.dense_timeline
+            else:
+                return int((val + .000000001) * self.args.dense_timeline)
+        else:
+            return val
+
+    def __build_timeline(self):
         timeline = {}
-        self.events = None
-        if 'Results' in jdata and 'worker_results' in jdata['Results']:
-            self.events = {}
-            for result in jdata['Results']['worker_results']:
+        events = None
+        if 'Results' in self._jdata and 'worker_results' in self._jdata['Results']:
+            events = {}
+            for result in self._jdata['Results']['worker_results']:
                 name = f'{result["pod"]}.{result["namespace"]}'
-                node = pod_node[name]
+                node = self.pod_node[name]
                 if node not in timeline:
-                    self.events[node] = []
+                    events[node] = []
                     self.work[node] = 0
                     self.start_times[node] = None
                     self.end_times[node] = None
                     timeline[node] = {}
-                    timeline[node][0.0] = {'increment': 0, 'active': 0, 'rate': 0}
+                    timeline[node][0.0] = {'request': 0, 'in_use': 0, 'jobs': 0, 'rate': 0, 'events': {}}
                 for case in result['cases']:
-                    start_time = case['start_time']
-                    end_time = case['end_time']
+                    start_time = case['start_time'] - self._summary['first_pod_start_time']
+                    end_time = case['end_time'] - self._summary['first_pod_start_time']
+                    if 'prealloc_time' in case:
+                        alloc_time = case['alloc_time'] - self._summary['first_pod_start_time']
+                        prefree_time = case['prefree_time'] - self._summary['first_pod_start_time']
+                    else:
+                        alloc_time = start_time
+                        prefree_time = end_time
                     if self.net_start_time is None or start_time < self.net_start_time:
                         self.net_start_time = start_time
                     if self.net_end_time is None or end_time > self.net_end_time:
@@ -62,78 +175,175 @@ class memory_reporter(ClusterBusterReporter):
                         self.start_times[node] = start_time
                     if self.end_times[node] is None or end_time > self.end_times[node]:
                         self.end_times[node] = end_time
-                    elapsed = end_time - start_time
+                    elapsed = prefree_time - alloc_time
                     pages = case['pages']
                     memory = case['size']
                     self.work[node] += pages
                     self.work_total += pages
-                    if start_time in timeline[node]:
-                        timeline[node][start_time]['increment'] += memory
-                        timeline[node][start_time]['active'] += 1
-                        timeline[node][start_time]['rate'] += pages / elapsed
-                    else:
-                        timeline[node][start_time] = {'increment': memory}
-                        timeline[node][start_time]['active'] = 1
-                        timeline[node][start_time]['rate'] = pages / elapsed
-                    if end_time in timeline[node]:
-                        timeline[node][end_time]['increment'] -= memory
-                        timeline[node][end_time]['active'] -= 1
-                        timeline[node][end_time]['rate'] -= pages / elapsed
-                    else:
-                        timeline[node][end_time] = {'increment': -memory}
-                        timeline[node][end_time]['active'] = -1
-                        timeline[node][end_time]['rate'] = -pages / elapsed
-            current = 0
+                    for time in [start_time, alloc_time, prefree_time, end_time]:
+                        if time not in timeline[node]:
+                            timeline[node][time] = {'request': 0, 'in_use': 0, 'jobs': 0, 'rate': 0, 'events': {}}
+                    timeline[node][start_time]['events']['alloc'] = 1
+                    timeline[node][start_time]['request'] += memory
+                    timeline[node][alloc_time]['events']['inuse'] = 1
+                    timeline[node][alloc_time]['jobs'] += 1
+                    timeline[node][alloc_time]['in_use'] += memory
+                    timeline[node][alloc_time]['rate'] += pages / elapsed
+                    timeline[node][prefree_time]['events']['free'] = 1
+                    timeline[node][prefree_time]['request'] -= memory
+                    timeline[node][prefree_time]['jobs'] -= 1
+                    timeline[node][prefree_time]['rate'] -= pages / elapsed
+                    timeline[node][end_time]['events']['done'] = 1
+                    timeline[node][end_time]['in_use'] -= memory
+            current_request = 0
+            current_in_use = 0
             max = 0
-            active = 0
+            jobs = 0
             rate = 0
             for node, subtimeline in timeline.items():
+                current_idx = -1
+                inode = {'instance': node}
+                nnode = {'node': node}
                 for time in sorted(subtimeline.keys()):
                     e = subtimeline[time]
-                    increment = e['increment']
-                    active += e['active']
-                    current += increment
+                    request = e['request']
+                    in_use = e['in_use']
+                    jobs += e['jobs']
                     rate += e['rate']
-                    if current > max:
-                        max = current
+                    current_request += request
+                    current_in_use += in_use
+                    if current_in_use > max:
+                        max = current_in_use
+                    if not self.args.precise_timeline:
+                        time = self.inttime(int(self.timeint(time)))
+                    if ((current_idx >= 0 and self.args.dense_timeline and
+                         int(time) > int(self.timeint(events[node][current_idx]['time'])) + 1)):
+                        prev = events[node][current_idx]
+                        for i in range(int(self.timeint(prev['time'])) + 1, int(self.timeint(time))):
+                            itime = self.inttime(i)
+                            event = {
+                                'time': itime,
+                                'jobs': prev['jobs'],
+                                'current_request': prev['current_request'],
+                                'current_in_use': prev['current_in_use'],
+                                'max': prev['max'],
+                                'work_rate': prev['work_rate'],
+                                'node_in_use': int(self.get_adj_metric('nodeMemoryInUse-Workers', itime, inode)),
+                                'working_set': int(self.get_adj_metric('containerMemoryWorkingSet-clusterbuster', itime, nnode)),
+                                'node_CPU': round(self.get_adj_metric('nodeCPUUtil-Workers', itime, inode), 3),
+                                'container_CPU': round(self.get_adj_metric('containerCPU-clusterbuster', itime, nnode), 3)
+                                }
+                            events[node].append(event)
+                            current_idx += 1
                     event = {
                         'time': time,
-                        'increment': increment,
-                        'active': active,
-                        'current': current,
+                        'request': request,
+                        'jobs': jobs,
+                        'current_request': current_request,
+                        'current_in_use': current_in_use,
                         'max': max,
-                        'work_rate': rate
+                        'work_rate': rate,
+                        'node_in_use': int(self.get_adj_metric('nodeMemoryInUse-Workers', time, inode)),
+                        'working_set': int(self.get_adj_metric('containerMemoryWorkingSet-clusterbuster', time, nnode)),
+                        'node_CPU': round(self.get_adj_metric('nodeCPUUtil-Workers', time, inode), 3),
+                        'container_CPU': round(self.get_adj_metric('containerCPU-clusterbuster', time, nnode), 3)
                         }
-                    self.events[node].append(event)
-        self._set_header_components(['namespace', 'pod', 'container', 'process_id'])
+                    if current_idx >= 0 and time == events[node][current_idx]['time']:
+                        events[node][current_idx] = event
+                    else:
+                        events[node].append(event)
+                        current_idx += 1
+        return events
+
+    def build_timeline(self):
+        if self.timeline is None:
+            try:
+                self.timeline = self.__build_timeline()
+            except (TypeError, ValueError, KeyError):
+                print(f"Unable to build timeline: {traceback.format_exc()}", file=sys.stderr)
+                self.timeline = False
+        elif self.timeline is False:
+            pass
 
     def pp(self, val, suffix: str = 'B'):
-        return self._prettyprint(val, precision=3, base=1024, suffix=suffix)
-
-    def format_timeline(self, timeline: dict):
-        if self.events is None or self._report_format == 'none' or 'summary' in self._report_format:
-            return None
-        elif self._report_format == 'verbose':
-            return '\n'.join([f'Node: {node}\n  ' +
-                              '\n  '.join(['Time %10.3f  In Use %12s  Delta %13s  Jobs %4d  Maximum %12s  Rate %18s' %
-                                           (event['time'], self.pp(event['current']), self.pp(event['increment']),
-                                            event['active'], self.pp(event['max']),
-                                            self.pp(round(event['work_rate'], 0), ' pp/sec'))
-                                           for event in timeline[node]])
-                              for node in sorted(timeline.keys())])
+        if self.args.numeric_timeline:
+            return str(int(val))
         else:
-            return timeline
+            return self._prettyprint(val, precision=3, base=1024, suffix=suffix)
+
+    def format_to_spec(self, value, fmt: str):
+        if fmt is False:
+            return str(value)
+        else:
+            return fmt % (value)
+
+    def format_column(self, event: dict, column: str, definition: dict):
+        value = event.get(column, 0)
+        if 'round' in definition:
+            value = round(value, definition['round'])
+        if ('precise_format' in definition and
+            ((self.args.precise_timeline and 'precise_format' in definition) or
+             (self.args.dense_timeline is not None and self.args.dense_timeline % 1))):
+            return self.format_to_spec(value, definition['precise_format'])
+        elif 'format' in definition:
+            return self.format_to_spec(value, definition['format'])
+        return self.pp(value)
+
+    def format_timeline_text(self, timeline_format=None):
+        if timeline_format is None:
+            timeline_format = 'tsv'
+        sep = self.SEPARATORS[timeline_format]
+        return '\n'.join([f"Node: {node}\n{sep.join([col['header'] for col in self.columns.values()])}\n" +
+                          '\n'.join([sep.join([self.format_column(event, name, column)
+                                               for name, column in self.columns.items()])
+                                     for event in self.timeline[node]])
+                          for node in sorted(self.timeline.keys())])
+
+    def format_timeline(self, report_format=None, timeline_format=None):
+        if report_format is None:
+            report_format = self._report_format
+        if timeline_format is not None:
+            if self.timeline is None:
+                return None if timeline_format == 'json' else ''
+            if timeline_format == 'json':
+                return json.dumps(self.timeline, indent=2)
+            else:
+                return self.format_timeline_text(timeline_format)
+        elif self.timeline is None or report_format is None or 'summary' in report_format:
+            return None
+        elif report_format == 'verbose':
+            return self.format_timeline_text()
+        else:
+            return self.timeline
+
+    def get_adj_metric(self, metric_name: str, time: float, selector: dict = None):
+        answer = self._get_metric_value(metric_name, time + self._summary['first_pod_start_time'], selector)
+        if answer is None:
+            return 0
+        else:
+            return answer
 
     def _generate_summary(self, results: dict):
         # I'd like to do this, but if the nodes are out of sync time-wise, this will not
         # function correctly.
         ClusterBusterReporter._generate_summary(self, results)
+        self.build_timeline()
         results['Pages Scanned'] = self._prettyprint(self.work_total,
-                                                  precision=3, base=1000, suffix=' it')
-        results['Pages Scanned/sec'] = self._prettyprint(self._safe_div(self.work_total,
-                                                                        self.net_end_time - self.net_start_time),
-                                                      precision=3, base=1000, suffix=' pp/sec')
-        timeline = self.format_timeline(self.events)
+                                                     precision=3, base=1000, suffix=' it')
+        if self.net_end_time is not None and self.net_start_time is not None:
+            results['Pages Scanned/sec'] = self._prettyprint(self._safe_div(self.work_total,
+                                                                            self.net_end_time - self.net_start_time),
+                                                             precision=3, base=1000, suffix=' pp/sec')
+        if self.args.timeline_file:
+            if self.timeline:
+                timeline_report = self.format_timeline(timeline_format=self.args.timeline_format)
+                if self.args.timeline_file == '-':
+                    print(timeline_report)
+                with open(self.args.timeline_file, 'w') as fp:
+                    print(timeline_report, file=fp)
+            else:
+                raise TypeError("Unable to report timeline: no events")
+        timeline = self.format_timeline()
         if timeline:
             results['Timeline'] = timeline
 

--- a/lib/clusterbuster/reporting/reporter/memory_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/memory_reporter.py
@@ -42,7 +42,8 @@ class memory_reporter(ClusterBusterReporter):
             'header': 'Workload Memory In Use'
             },
         'jobs': {
-            'header': 'Jobs'
+            'header': 'Jobs',
+            'format': False
             },
         'max': {
             'header': 'Maximum Workload Request'

--- a/lib/clusterbuster/reporting/reporter/server_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/server_reporter.py
@@ -18,8 +18,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class server_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras)
         self._add_accumulators(['data_sent_bytes', 'passes', 'mean_latency_sec', 'max_latency_sec'])
         self._set_header_components(['namespace', 'pod', 'container'])
 

--- a/lib/clusterbuster/reporting/reporter/sysbench_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/sysbench_reporter.py
@@ -19,8 +19,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class sysbench_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras)
         self._set_header_components(['namespace', 'pod', 'container', 'process_id'])
         self._is_fileio = 'sysbench_fileio_tests' in jdata['metadata']['options']['workloadOptions']
         if self._is_fileio:

--- a/lib/clusterbuster/reporting/reporter/uperf_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/uperf_reporter.py
@@ -18,8 +18,8 @@ from .ClusterBusterReporter import ClusterBusterReporter
 
 
 class uperf_reporter(ClusterBusterReporter):
-    def __init__(self, jdata: dict, report_format: str):
-        super().__init__(jdata, report_format)
+    def __init__(self, jdata: dict, report_format: str, extras=None):
+        super().__init__(jdata, report_format, extras)
         fields_to_copy = []
         self._jobs = jdata['metadata']['workload_metadata']['jobs']
         self._job_names = list(self._jobs.keys())

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -27,6 +27,8 @@ declare -ig ___memory_sync=1
 declare -g ___memory_random_seed=
 declare -g ___memory_iteration_runtime=10
 declare -ig ___memory_idle_first=2
+declare -ig ___memory_subproc=0
+declare -g ___memory_start_probability=
 
 function memory_arglist() {
     local mountdir=$1; shift
@@ -35,7 +37,8 @@ function memory_arglist() {
 		 "${workload_run_time}" "$___memory_size" "$___memory_scan" \
 		 "$___memory_stride" "$___memory_iterations" \
 		 "$___memory_idle" "$___memory_random_seed" "$___memory_sync" \
-		 "$___memory_iteration_runtime" "$___memory_idle_first"
+		 "$___memory_iteration_runtime" "$___memory_idle_first" \
+		 "$___memory_subproc" "$___memory_start_probability"
 }
 
 function memory_create_deployment() {
@@ -80,13 +83,19 @@ function memory_help_options() {
                         Amount of memory to allocate.  If two values
                         are provided, a random value between the two
                         is used for each iteration.  Step allows specifying
-			the step size.
+                        the step size.
        --memory-scan=<0,1>
                         Write scan memory continuously
        --memory-stride=<size>
                         Stride the specified number of bytes
                         when scanning.  Default is system pagesize.
                         Set to 1 to scan every byte.
+       --memory-iteration-runtime=<seconds[,max_seconds][,step]>
+                        The time for each iteration of the test.
+                        Default is not set, in which case the
+                        --workload-runtime and --memory-iterations
+                        control how long the test is run.  This may not
+                        be used if --memory-sync-between-iterations is set.
        --memory-iterations=<n>
                         Run the scan for the specified number of
                         iterations.  Default is 1.
@@ -97,12 +106,6 @@ function memory_help_options() {
                         Sleep first before starting operations.
                         Value of 2 means to randomly sleep or not
                         for the first operation.  Default $memory_idle_first.
-       --memory-iteration-runtime=<seconds[,max_seconds][,step]>
-			The time for each iteration of the test.
-                        Default is not set, in which case the
-                        --workload-runtime and --memory-iterations
-                        control how long the test is run.  This may not
-                        be used if --memory-sync-between-iterations is set.
        --memory-random-seed=<seed>
                         Use the specified value in combination with
                         the pod ID to randomize the run.  The seed
@@ -112,6 +115,17 @@ function memory_help_options() {
                         Most useful to set this to no is when running
                         random workloads when it is desired there to be
                         overlap between operations.
+       --memory-start-probability=<"" | 0.000 - 1.000>
+                        Probability of memory allocation starting with
+                        memory allocation as opposed to sleeping.
+                        If empty, probability is calculated based on
+                        average duty cycle computed as the average
+                        iteration runtime divided by the sum of the
+                        average iteration runtime and the average idle
+                        runtime.
+       --memory-subproc=<0,1>
+                        Run iterations as subprocesses rather than function
+                        calls, to be certain that memory is released.
 EOF
 }
 
@@ -129,13 +143,11 @@ function memory_process_options() {
 	    memoryidle*)	 ___memory_idle=$(parse_size -d, "$optvalue")		  ;;
 	    memoryrandom*)	 ___memory_random_seed=$(base64 -w 0 <<< "$optvalue")	  ;;
 	    memorysync*)	 ___memory_sync=$(bool "$optvalue")			  ;;
-	    memorytotal*)	 ___memory_total_runtime=$(parse_size "$optvalue")	  ;;
+	    memorysubproc*)	 ___memory_subproc=$(bool "$optvalue")			  ;;
+	    memorystartprob*)	 ___memory_start_probability="$optvalue"		  ;;
 	    *)			 unknown_opts+=("$noptname ($noptname1)")		  ;;
 	esac
     done
-    if ((___memory_sync && ___memory_total_runtime > 0)) ; then
-	fatal "--memory-total-runtime may not be set if --memory-sync is also set"
-    fi
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
 	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
@@ -156,13 +168,15 @@ function memory_report_options() {
 	
     cat <<EOF
 "memory_size": $(mk_num_list "$___memory_size"),
+"memory_scan": $___memory_scan,
 "memory_stride": $___memory_stride,
 "memory_iterations": $___memory_iterations,
-"memory_idle": $(mk_num_list "$___memory_idle"),
-"memory_scan": $___memory_scan,
 "memory_iteration_time": $(mk_num_list "$___memory_iteration_runtime"),
+"memory_idle": $(mk_num_list "$___memory_idle"),
 "memory_random_seed": "$___memory_random_seed",
-"memory_sync_between_iterations": "$___memory_sync"
+"memory_sync_between_iterations": "$___memory_sync",
+"memory_subproc": $___memory_subproc,
+"memory_start_probability": $(if [[ -n "$___memory_start_probability" ]] ; then printf '%f' "$___memory_start_probability" ; else echo -1; fi)
 EOF
 }
 


### PR DESCRIPTION
* Add memory in use metric, and average metrics, to summary report.
* Only look at metrics captured during the active part of a run.
* Extend the prometheus snapshot in time to fully capture the beginning and end of the run.
* Report an error if a reporter fails to load due to a syntax error.
* Simplify the timeline report from the memory reporter.
* Allow memory jobs to be run as either subprocesses or function calls.
* Sync immediately before releasing memory if sync requested.
* Allow additional options for individual reporters.
* Add --metrics-interval option.
* Add --report-format as alias for -o for clusterbuster-report.
* Handle "oc version" correctly.
* Allow intervals other than 1 second for dense timeline.
* Clean up exception use in reporter to raise specific exceptions and (where practicable),  not simply catch Exception.
* Prefix parseable results with the path to the report directory