### PR TITLE
Clean up some leftover workloadOptions

### DIFF
--- a/lib/clusterbuster/reporting/reporter/fio_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/fio_reporter.py
@@ -94,7 +94,7 @@ class fio_reporter(ClusterBusterReporter):
             for k, v in sample_row['global options'].items():
                 if k not in ['rw', 'bs']:
                     results[k] = v
-        results['\nFIO job file'] = base64.b64decode(self._jdata['metadata']['options']['workloadOptions']['fio_job_file']).decode()
+        results['\nFIO job file'] = base64.b64decode(self._get_workload_options()['fio_job_file']).decode()
         results['\nJobs'] = {}
         self.__update_report(results['\nJobs'], self._summary['results'], 'max_max', int(self._summary['total_instances']))
 

--- a/lib/clusterbuster/reporting/reporter/sysbench_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/sysbench_reporter.py
@@ -22,19 +22,19 @@ class sysbench_reporter(ClusterBusterReporter):
     def __init__(self, jdata: dict, report_format: str, extras=None):
         super().__init__(jdata, report_format, extras)
         self._set_header_components(['namespace', 'pod', 'container', 'process_id'])
-        self._is_fileio = 'sysbench_fileio_tests' in jdata['metadata']['options']['workloadOptions']
+        self._is_fileio = 'sysbench_fileio_tests' in self._get_workload_operations()
         if self._is_fileio:
             self.__initialize_fileio(jdata)
         else:
             self.__initialize_simple(jdata)
 
     def __initialize_fileio(self, jdata):
-        if 'sysbench_fileio_modes' in jdata['metadata']['options']['workloadOptions']:
+        if 'sysbench_fileio_modes' in self._get_workload_operations():
             self._sysbench_operations = [f'fileio+{test}+{mode}'
-                                         for test in jdata['metadata']['options']['workloadOptions']['sysbench_fileio_tests']
-                                         for mode in jdata['metadata']['options']['workloadOptions']['sysbench_fileio_modes']]
+                                         for test in self._get_workload_operations()['sysbench_fileio_tests']
+                                         for mode in self._get_workload_operations()['sysbench_fileio_modes']]
         else:
-            self._sysbench_operations = jdata['metadata']['options']['workloadOptions']['sysbench_fileio_tests']
+            self._sysbench_operations = self._get_workload_operations()['sysbench_fileio_tests']
         self._sysbench_vars_to_copy = ['filesize:precision=3:suffix=B:base=1024',
                                        'blocksize:precision=3:suffix=B:base=1024', 'rdwr_ratio',
                                        'fsync_frequency', 'final_fsync_enabled', 'io_mode']


### PR DESCRIPTION
workloadOptions was renamed workload_options; there were still a few leftover old-style workloadOptions around.
Check for both so we can handle old reports.