### PR TITLE
Fixes to fio and files workloads

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -1744,6 +1744,10 @@ function _log_helper() {
 	    rm -f "$tmpfile"
 	    break
 	fi
+	if [[ ! -d "$cb_tempdir" ]] ; then
+	    timestamp <<< "Data retrieval failed!  Cannot retry" 1>&2
+	    return 1
+	fi
 	get_run_failed && return 1
 	timestamp <<< "Data retrieval failed!  Retrying" 1>&2
 	# One cause of failure is problems with cert rotation or other causes interfering
@@ -4271,6 +4275,11 @@ function validate_options() {
 	*)
 	    help "--deployment_type must be pod, vm, deployment, or replicaset"
     esac
+    if [[ ${deployment_type,,} != vm ]] ; then
+	vm_emptydisk_list=()
+	vm_emptydisks=()
+	vm_emptydisk_options=()
+    fi
 
     [[ -z "$OC" && $doit -gt 0 ]] && fatal "Cannot find oc or kubectl command, exiting!"
 

--- a/lib/clusterbuster/CI/workloads/files.workload
+++ b/lib/clusterbuster/CI/workloads/files.workload
@@ -68,7 +68,8 @@ function files_test() {
 			  --files_per_dir="$___files_per_dir" \
 			  --file_block_size="$___files_block_size" \
 			  --files_direct="$___files_direct" \
-			  --filesize="$file_size"
+			  --filesize="$file_size" \
+			  --vm-emptydisk="$(((((dirs_per_volume * files_per_dir * filesize * 11 / 10) + 1048575) / 1048576) * 1048576)):/var/tmp"
     done
 }
 

--- a/lib/clusterbuster/CI/workloads/files.workload
+++ b/lib/clusterbuster/CI/workloads/files.workload
@@ -26,6 +26,11 @@ declare -gi ___files_min_direct
 declare -gi ___files_drop_cache
 
 function files_test() {
+    function roundup() {
+	local -i base=$1
+	local -i interval=$2
+	echo $((((base + interval - 1) / interval) * interval))
+    }
     ___files_job_timeout=$(compute_timeout "$___files_job_timeout")
     if [[ -z "${___files_params[*]}" ]] ; then
 	for ninst in "${___files_ninst[@]}" ; do
@@ -60,6 +65,15 @@ function files_test() {
 	if ((___files_block_size > file_size && file_size > 0)) ; then
 	    ___files_block_size=$file_size
 	fi
+	local -i fs_block_size=4096 # Need a better way than hard coding this; assumes ext4
+	local -i inode_size_bytes=256 # Need a better way than hard coding this; assumes ext4
+	local -i bytes_per_file=file_size
+	if ((bytes_per_file < fs_block_size)) ; then bytes_per_file=fs_block_size; fi
+	bytes_per_file=$(roundup "$bytes_per_file" "$fs_block_size")
+	local -i inodes_required=$((1024 + ___files_dirs_per_volume + (___files_dirs_per_volume * ___files_per_dir)))
+	local -i bytes_required=$(((inodes_required * 256) + (bytes_per_file * ___files_dirs_per_volume * ___files_per_dir)))
+	# Add 12.5% overhead and round up to next MB
+	bytes_required=$(roundup $((bytes_required * 9 / 8)) 1048576)
 	job_name="${ninst}P-${___files_dirs_per_volume}D-${___files_per_dir}F-${___files_block_size}B-${file_size}S-${___files_direct}T"
 	# shellcheck disable=SC2090
 	run_clusterbuster -j "$job_name" -w files -t "$___files_job_timeout" -- \
@@ -69,7 +83,7 @@ function files_test() {
 			  --file_block_size="$___files_block_size" \
 			  --files_direct="$___files_direct" \
 			  --filesize="$file_size" \
-			  --vm-emptydisk="$(((((dirs_per_volume * files_per_dir * filesize * 11 / 10) + 1048575) / 1048576) * 1048576)):/var/tmp"
+			  --vm-emptydisk="$bytes_required:fsopts=-N ${inodes_required}:/var/tmp"
     done
 }
 

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -40,7 +40,7 @@ function files_arglist() {
     local dc_port=0
     while [[ "$1" != '--' ]] ; do shift; done; shift
     local -i file_blocks=$((___file_size/___file_block_size))
-    local mounts=("${volume_mount_paths[@]}" "${emptydirs[@]}")
+    local mounts=("${volume_mount_paths[@]}" "${emptydirs[@]}" "${vm_emptydisk_list[@]}")
     mk_yaml_args "python3" "${mountdir}files.py" "$@" \
 		 "$___file_dirs_per_volume" "$___files_per_dir" "$___file_block_size" "$file_blocks" \
 		 "$processes_per_pod" "$___files_direct" "${mounts[@]}"


### PR DESCRIPTION
- fio:
  - fio prints some warnings on stdout rather than stderr, so we need to direct its output into a file.
  - Re-raise errors correctly
- files:
  - If emptydisk volume is specified for files workload, use it rather than /tmp.