### PR TITLE
Improve support for volumes with VM workloads and rationalize the volume CLI

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -88,6 +88,8 @@ declare -a failures=()
 declare -a jobs=()
 declare -A job_runtimes=()
 declare -A runtimeclass_ok=()
+declare prerun=
+declare postrun=
 
 declare starting_timestamp=
 declare job_datestamp
@@ -220,6 +222,8 @@ function finis() {
 	    for job in "${jobs[@]}" ; do
 		printf "%10s %s\n" "${job_runtimes[$job]}" "$job"
 	    done
+	else
+	    fail=1
 	fi
 	if [[ -n "${failures[*]}" ]] ; then
 	    echo "Failing jobs:"
@@ -323,13 +327,17 @@ function splitarg() {
 function get_available_nodes() {
     local -a nodes
     local role
-    for role in 'node-role.kubernetes.io/clusterbuster=' 'node-role.kubernetes.io/worker=,node-role.kubernetes.io/master!=,node-role.kubernetes.io/infra!=' 'node-role.kubernetes.io/worker=' ; do
-	readarray -d ' ' -t nodes < <("${OC}" get node -l "$role" -o jsonpath='{.items[*].metadata.name}')
-	if ((${#nodes[@]} >= 1)) ; then
-	    echo "${nodes[*]}"
-	    return
-	fi
-    done
+    if ((debugonly)) ; then
+	echo node1 node2 node3
+    else
+	for role in 'node-role.kubernetes.io/clusterbuster=' 'node-role.kubernetes.io/worker=,node-role.kubernetes.io/master!=,node-role.kubernetes.io/infra!=' 'node-role.kubernetes.io/worker=' ; do
+	    readarray -d ' ' -t nodes < <("${OC}" get node -l "$role" -o jsonpath='{.items[*].metadata.name}')
+	    if ((${#nodes[@]} >= 1)) ; then
+		echo "${nodes[*]}"
+		return
+	    fi
+	done
+    fi
     (IFS=$'\n'; echo "${nodes[*]}")
 }
 
@@ -357,9 +365,13 @@ function set_pin_nodes() {
 
 function get_node_memory() {
     local node=$1
-    local mem
-    mem=$("${OC}" get node "$node" -ojsonpath='{.status.allocatable.memory}')
-    parse_size "$mem"
+    if ((debugonly)) ; then
+	echo "$((32 * 1024 * 1024 * 1024))"
+    else
+	local mem
+	mem=$("${OC}" get node "$node" -ojsonpath='{.status.allocatable.memory}')
+	parse_size "$mem"
+    fi
 }
 
 function list_profiles() {
@@ -379,17 +391,32 @@ function list_profiles() {
 
 function process_profile() {
     local profile=$1
-    if [[ -f "${__profiledir__}/${profile}.profile" ]] ; then
+    local profile_in_dir=0
+    if [[ $profile != *'/'* ]] ; then
+	profile="${__profiledir__}/${profile}.profile"
+	profile_in_dir=1
+    fi
+    if [[ -f "$profile" && -r "$profile" ]] ; then
 	local line=
 	while IFS= read -r line ; do
+	    # shellcheck disable=SC1003
+	    while [[ $line = *'\' ]] ; do
+		line=${line::-1}
+		local tline
+		IFS= read -r tline
+		[[ -z "$tline" ]] && break
+		line+="$tline"
+	    done
 	    line=${line%%#*}
 	    line=${line## }
 	    line=${line##	}
 	    if [[ -z "$line" ]] ; then continue; fi
 	    process_option "$line"
-	done < "${__profiledir__}/${profile}.profile"
-    else
+	done < "$profile"
+    elif ((profile_in_dir)) ; then
 	fatal "Cannot find profile $profile in $__profiledir__"
+    else
+	fatal "Cannot find profile $profile"
     fi
 }
 
@@ -477,8 +504,12 @@ $(list_profiles '                                - ')
                                 distinct string to aid in later identification.
 
     All other options listed below may be of the form
-    --option:<workload>=value to specify that the value should apply
-    only to a particular workload.
+    --option:<workload><runtime>=value to specify that the value should apply
+    only to a particular workload and runtimeclass.  Either workload or
+    runtimeclass may be omitted or be of the form
+    :workload
+    :workload1,workload2 (list)
+    :!workload (negation)
 
     Workload-specific options:
 $(_help_options_workloads)
@@ -508,6 +539,104 @@ function set_pin_node() {
     fi
 }
 
+function _check_ci_option() {
+    local noptname=$1
+    local workload=$2
+    local runtime=$3
+    if [[ $noptname = *':'* && (-n "$workload" || -n "$runtime") ]] ; then
+	local optbase=
+	local optworkload=
+	local optruntime=
+	# shellcheck disable=SC2034
+	IFS=: read -r optbase optworkload optruntime <<< "$noptname"
+	if [[ (-z "$workload" || -z "$optworkload" || $workload = "$optworkload") &&
+		  (-z "$runtime" || -z "$optruntime" || $runtime = "$optruntime") ]] ; then
+	    true
+	elif [[ $optworkload = *'!'* || $optworkload = *','* ||
+		    $optruntime = *'!'* || $optruntime = *','* ]] ; then
+	    local -a optworkloads
+	    local -a optruntimes
+	    IFS=, read -ra optworkloads <<< "$optworkload"
+	    IFS=, read -ra optruntimes <<< "$optruntime"
+	    local item
+	    if [[ -n "$workload" && -n "$optworkload" ]] ; then
+		local found=0
+		for item in "${optworkloads[@]}" ; do
+		    if [[ $item = "$workload" ]] ; then
+			found=1
+			break
+		    elif [[ $item = '!'* && ${item:1} = "$workload" ]] ; then
+			return 1
+		    fi
+		done
+		((found)) || return 1
+	    fi
+	    if [[ -n "$runtime" && -n "$optruntime" ]] ; then
+		local found=0
+		for item in "${optruntimes[@]}" ; do
+		    [[ $item = "$runtime" || ($item = '!'* && ${item:1} != "$runtime") ]] && return 0
+		done
+		return 1
+	    fi
+	    return 0
+	else
+	    return 1
+	fi
+    fi
+}
+
+function parse_ci_option() {
+    local option=$1
+    local workload=${2:-}
+    local runtime=${3:-}
+    local noptname1 noptname optvalue
+    read -r noptname1 noptname optvalue <<< "$(parse_option "$option")"
+    if _check_ci_option "$noptname" "$workload" "$runtime" ; then
+	echo "${noptname1/:*/} ${noptname/:*/} $optvalue"
+	return 0
+    else
+	return 1
+    fi
+}
+
+function test_parse() {
+    function _test_parse() {
+	if parse_ci_option "$@" >/dev/null ; then
+	    echo "Y  $(parse_ci_option "$@")"
+	else
+	    echo "   $(parse_ci_option "$@")"
+	fi
+    }
+
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files kata
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio kata
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker kata
+    _test_parse volume:files:!pod,!kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto
+    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files
+    _test_parse volume:files:vm,kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:pod,kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster:size=auto fio
+}
+
 function check_clusterbuster_option() {
     local option=$1
     if [[ -z "${known_clusterbuster_options[*]}" ]] ; then
@@ -526,7 +655,7 @@ function process_option() {
     local optvalue
     local workload
     # shellcheck disable=SC2034
-    read -r noptname1 noptname optvalue workload <<< "$(parse_option -w "$option")"
+    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$option")"
     optvalue=$(splitarg "$optvalue")
     case "$noptname1" in
 	help*) help									;;
@@ -559,10 +688,13 @@ function process_option() {
     esac
 }
 
-
 function process_workload_options() {
-    local workload="$1"
-    shift
+    local OPTIND=0
+    local opt
+    local OPTARG
+    local workload=${1:-}
+    local runtimeclass=${2:-}
+    shift 2
     extra_clusterbuster_args=()
     call_api -s -w "$workload" initialize_options
     local option
@@ -572,14 +704,16 @@ function process_workload_options() {
 	local optvalue
 	local optworkload
 	# shellcheck disable=SC2034
-	read -r noptname1 noptname optvalue optworkload <<< "$(parse_option -w "$option")"
-	[[ -n "$optworkload" && $workload != "$optworkload" ]] && continue
-	optvalue=$(splitarg "$optvalue")
-	if ! call_api -A -a -w "$workload" process_option "$option" ; then
-	    if check_clusterbuster_option "$noptname1" ; then
-		extra_clusterbuster_args+=("--$noptname=$optvalue")
-	    else
-		fatal "Unknown option $option"
+	read -r noptname1 noptname optvalue <<< "$(parse_option "$option" "$workload" "$runtimeclass")"
+	if [[ -n "$noptname1" ]] ; then
+	    optvalue=$(splitarg "$optvalue")
+	    if ! call_api -A -a -w "$workload" process_option "$option" ; then
+		if check_clusterbuster_option "$noptname1" ; then
+		    extra_clusterbuster_args+=("--$noptname=$optvalue")
+		else
+		    stack_trace
+		    fatal "Unknown option $option ($noptname1)"
+		fi
 	    fi
 	fi
     done
@@ -781,13 +915,6 @@ function run_clusterbuster_1() {
     return $status
 }
 
-function run_clusterbuster() {
-    for runtimeclass in "${runtimeclasses[@]}" ; do
-	run_clusterbuster_1 -r "$runtimeclass" "$@"
-    done
-    counter=$((counter+1))
-}
-
 if [[ -z "${workloads[*]}" ]] ; then
     readarray -t workloads <<< "$(print_workloads)"
 fi
@@ -853,9 +980,18 @@ if ((! debugonly)) ; then
     fi
 fi
 
+if [[ -n "$prerun" && -x "$prerun" ]] ; then
+    echo "Running pre-run"
+    "$prerun" "$@"
+fi
+
 for workload in "${workloads[@]}" ; do
     # Use a separate counter for each workload/runtime
     counter=0
-    process_workload_options "$workload"
     call_api -w "$workload" test "$job_runtime"
 done
+
+if [[ -n "$postrun" && -x "$postrun" ]] ; then
+    echo "Running post-run"
+    "$postrun" "$@"
+fi

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ etc. OpenShift 4 clusters.
 
 - **monitor-cluster-resources** -- monitor CPU, memory, and pod
   utilization per-node in real time.
-  
+
 - **net-traffic** -- report information about network traffic similar
   to iostat.
 

--- a/clusterbuster
+++ b/clusterbuster
@@ -94,7 +94,8 @@ done
 declare -i namespaces=1
 declare -i use_namespaces=1
 declare -i deps_per_namespace=1
-declare -i remove_namespaces=1
+declare -i remove_namespaces=-1
+declare -i create_namespaces_only=0
 declare -i secrets=0
 declare -i replicas=1
 declare -i parallel=1
@@ -128,7 +129,7 @@ declare -i affinity=0
 declare -i sync_affinity=0
 declare -A pin_nodes=()
 declare -A runtime_classes=()
-declare runtime_class
+declare runtime_class=
 declare scheduler=
 declare -i verbose=0
 declare -i wait_for_secrets=1
@@ -157,13 +158,9 @@ declare sync_namespace=
 declare -i scale_ns=0
 declare -i scale_deployments=1
 declare -i sync_start=1
-declare -a emptydirs=()
 declare -a volumes=()
-declare -A volume_mount_paths=()
-declare -A volume_types=()
-declare -A volume_type_keys=()
-declare -A volume_scoped_names=()
-declare common_workdir=
+declare -A mount_volume_map=()
+declare common_workdir=/var/tmp/clusterbuster
 declare -i report=0
 declare report_format=summary
 declare -i precleanup=1
@@ -183,7 +180,6 @@ declare -i has_system_configmap=1
 declare -i has_user_configmap=1
 declare node_selector='node-role.kubernetes.io/worker'
 declare -i processes_per_pod=1
-declare -i emptydir_volumes=0
 declare -i take_prometheus_snapshot=0
 declare first_start_timestamp=
 declare prometheus_starting_timestamp=
@@ -221,12 +217,15 @@ declare -a extra_args=()
 declare -i metrics_interval=30
 declare -a sync_pod=()
 declare workload_step_interval=0
+declare -i preserve_tmpdir=0
+declare vm_ssh_keyfile=
+declare -r ssh_alg=ed25519
 
 declare -r sync_flag_file="/tmp/syncfile";
 declare -r sync_error_file="/tmp/syncerror";
 declare -r controller_timestamp_file="/tmp/timing.json";
-# shellcheck disable=2155
-declare uuid=$(uuidgen -r)
+declare uuid
+uuid=$(uuidgen -r)
 declare xuuid=$uuid
 # Ensure that pods from other runs don't inadvertently attempt to
 # communicate with our sync pod
@@ -260,19 +259,15 @@ declare vm_run_as_container=0
 declare -A workload_service_ports=()
 declare vm_user=cluster
 declare vm_password=buster
-declare -a vm_ssh_pubkey=()
 declare -A __sysctls=()
 declare -i __sysctls_retrieved=0
-declare -A vm_emptydisks=()
-declare -A vm_emptydisk_options=()
-declare -a vm_emptydisk_list=()
-# We can't use vda, which is the system disk
-declare -r vm_emptydisk_suffixes="bcdefghijklmnopqrstuvwxyz"
 
 declare OC=${OC:-${KUBECTL:-}}
 OC=${OC:-$(type -p oc)}
 OC=${OC:-$(type -p kubectl)}	# kubectl might not work, though...
 OC=$(type -p "$OC")
+
+declare VIRTCTL=${VIRTCTL:-$(type -p virtctl)}
 
 function fatal() {
     local OPTIND
@@ -327,7 +322,9 @@ Usage: ${__topsc__:-0} [options] [extra args]
                        All objects are labeled with this name.
        -E              Don't exit after all operations are complete.
        -e              Exit after all operations are complete (default).
-       -f jobfile      Job file containing settings
+       -f jobfile      Job file containing settings.
+                       Continuations may be escaped with a trailing
+                       backslash.
                        A number of examples are provided in the
                        examples/clusterbuster directory.
        -n              Print what would be done without doing it
@@ -350,6 +347,8 @@ function _help_extended() {
 Extended Options:
     General Options (short equivalents):
        --doit=<1,0>     Run the command or not (default 1) (inverse of -n)
+       --create-namespaces-only
+                        Only create namespaces.
        --jobname=name   Name of the job, for logging purposes.
                         Defaults to the workload name
        --workload=type  Specify the workload (-P) (mandatory)
@@ -365,6 +364,8 @@ Extended Options:
        --remove-namespaces=<1,0>
                         Remove namespaces when cleaning up objects.  Only
                         applies when using clusterbuster-created namespaces.
+                        By default, namespaces are removed only if no
+                        namespaces previously existed.
        --predelay=N     Delay for the specified time after workload
                         starts before it starts running.
        --postdelay=N    Delay for the specified time after workload
@@ -486,24 +487,54 @@ $(print_workloads_supporting_reporting '                        - ')
        --drop_all_cache Drop the buffer cache on all workers.
 
     Generic workload storage options:
-       --emptydir=dir   Mount an emptydir volume at the specified mount point.
-       --volumes=N      Mount the specified number of emptydir volumes.
-                        If this is not provided, file-based workloads will
-                        use a default location, generally /tmp.
-       --volume=name:type:name_type:mount_name:mount_path
-                        Mount a specified persistent volume
-                        name is the name of the volume (required).
-                        type is the type of volume (required).
-                        mount_path is the path on which to mount the volume
+       --volume=name:type:mount_path:options
+                        Mount a specified volume.
+                        - name is the name of the volume
+                        - type is the type of volume.
+                          Currently supported volume types are:
+                          - emptydir (pods only; no name required)
+                          - emptydisk (VMs only; no name required)
+                          - pvc or persistentvolumeclaim
+                        - mount_path is the path on which to mount the volume
                             (required).
-                        type_key is the key for the volume (e. g.
-                            claimName for persistentVolumeClaim)
-                        scoped_name is the volume's name as recognized
-                            by the description.  All occurrences of %N
-                            are replaced by the namespace of the pod
-                            mounting the volume; all instances of %i
-                            are replaced by the instance of the pod
-                            within the namespace.
+                        Options currently supported include the following:
+                           - claimName is the name of a PVC if it differs
+                             from the volume name.  This allows use of
+                             different PVCs; all occurrences of %N
+                             are replaced by the namespace of the pod
+                             mounting the volume; all instances of %i
+                             are replaced by the instance of the pod
+                             within the namespace.
+                           - size in bytes (required for emptydisk; ignored for
+                             other volume types).
+                           - inodes in number (optional for emptydisk; ignored
+                             for other volume types).
+                           - bus (VMs; ignored for pods): bus to be used
+                             for the volume (default virtio)
+                           - cache (VMs): caching mode (none, writeback,
+                             writethrough; default none)
+                           - fstype (VMs): filesystem type to format
+                             the volume to; empty means to not format
+                             the volume (filesystem must already be present).
+                             fsopts (VMs): options to use for formatting
+                             the filesystem.
+                           - mountopts (VMs): mount options to be used.
+                        Notes:
+                          - A previously declared mount can be overridden
+                            by specifying a later mount with the same
+                            mountpoint.
+                          - A previously declared mount can be removed by
+                            specifying a mount with the same mountpoint
+                            and empty name and type.  Example:
+                            --volume=:emptydir:/var/tmp/clusterbuster
+                            --volume=::/var/tmp/clusterbuster
+                            will result in no mount on /var/tmp/clusterbuster
+                            unless later overridden.
+                          - All previously declared mounts can be removed
+                            by specifying a mount with no name, type,
+                            mountpoint, or options.  Example:
+                            --volume=::
+                            will remove all mounts from the list.
        --workdir=<dir>  Use the specified working directory for file I/O
 
     Pod Options:
@@ -573,12 +604,6 @@ $(print_workloads_supporting_reporting '                        - ')
                         Specify the number of sockets (default $vm_sockets).
        --vm-memory=<value>
                         Specify the amount of memory (default $vm_memory).
-       --vm-emptydisk=<size:[options:]mountpoint>
-                        Create and mount an emptydisk volume in each VM.  Options are:
-                        - cache=<mode>
-                        - mountopts=<options>
-                        - fstype=<filesystem>
-                        - fsopts=<mkfs opts>
        --vm-grace-period=<value>
                         Specify the period between when a vm is signaled to
                         shutdown and the point when KubeVirt will force off
@@ -597,10 +622,11 @@ $(print_workloads_supporting_reporting '                        - ')
        --vm-password=<password>
                         Create the specified password on virtual machines.
                         Default $vm_password.  Empty means no password.
-       --vm-ssh-pubkey=<file>
-                        Inject the specified ssh key into the virtual machines.
-                        The file is checked to ensure that it is a public
-                        key.  Default none.
+       --vm-ssh-keyfile=file
+                        Inject the public key of the specified key pair into
+                        VMs for log retrieval or other access purposes.
+                        Default none, in which case a temporary key
+                        is generated.
 
     Tuning object creation (short equivalents):
        --scale-ns=[0,1] Scale up the number of namespaces vs.
@@ -664,6 +690,9 @@ Advanced options (generally not required):
                         For testing purposes, inject the specified error
                         condition (documented only in code).
        --force-abort    Abort the run on any error.
+       --preserve-tmpdir
+                        Do not remove the temporary directory at
+                        end of the run
 
 Here is a brief description of all available workloads:
 $(_document_workloads)
@@ -718,24 +747,6 @@ function set_runtime() {
     fi
 }
 
-function parse_volume_spec() {
-    local volspec=$1
-    local vname=
-    local vtype=
-    local vmount_path=
-    IFS=':' read -r vname vtype vmount_path vtype_key vscoped_name <<< "$volspec"
-    if [[ -z "$vname" || -z "$vtype" || -z "$vmount_path" ]] ; then
-	echo "name, type, type_key, scoped name, and mount path must be provided"
-	echo "for volumes"
-	exit 1
-    fi
-    volumes+=("$vname")
-    volume_mount_paths["$vname"]=$vmount_path
-    volume_types["$vname"]=$vtype
-    volume_type_keys["$vname"]=$vtype_key
-    volume_scoped_names["$vname"]=$vscoped_name
-}
-
 function process_pin_node() {
     local nodespec=$1
     nodespec=${nodespec// /}
@@ -758,6 +769,7 @@ function process_runtimeclass() {
     local runtimespec=$1
     if [[ $runtimespec = 'vm' ]] ; then
 	deployment_type=vm
+	runtime_class=vm
 	return
     fi
     runtimespec=${runtimespec// /}
@@ -775,32 +787,6 @@ function process_runtimeclass() {
     else
 	runtime_classes[default]="$runtimespec"
     fi
-}
-
-function process_emptydisk() {
-    local size
-    local mountpoint
-    local -a args
-    IFS=: read -ra args <<< "$1"
-    local -i argcount=${#args[@]}
-    if ((argcount < 2)) ; then
-	fatal "Invalid emptydisk $1: size and mount point must be specified as size:[args:]mountpoint"
-    fi
-    size=${args[0]}
-    mountpoint=${args[$((argcount - 1))]}
-    if [[ $mountpoint != '/'* ]] ; then
-	fatal "Invalid emptydisk $1: path must be absolute"
-    fi
-    if [[ -n "${vm_emptydisks[$mountpoint]:-}" ]] ; then
-	fatal "Duplicate emptydisk mount specified ($1)"
-    fi
-    if ((argcount > 2)) ; then
-	vm_emptydisk_options["$mountpoint"]="$(IFS=:; echo "${args[*]:1:$((argcount - 2))}")"
-    else
-	vm_emptydisk_options["$mountpoint"]=""
-    fi
-    vm_emptydisks["$mountpoint"]=$size
-    vm_emptydisk_list+=("$mountpoint")
 }
 
 function set_metrics_file() {
@@ -839,6 +825,7 @@ function process_option() {
 	doit)			    doit=$(bool "$optvalue")			;;
 	quiet)			    verbose=$((! $(bool "$optvalue")))		;;
 	forceabort*)		    set -e					;;
+	preservetmpdir)		    preserve_tmpdir=$(bool "$optvalue")		;;
 	# Reporting
 	artifactdir)		    artifactdir="$optvalue"			;;
 	metrics|metricsfile)	    set_metrics_file "$optvalue"		;;
@@ -864,6 +851,7 @@ function process_option() {
 	workload)		    requested_workload=$optvalue		;;
 	basename)		    basename=$optvalue				;;
 	arch)			    arch=$optvalue				;;
+	createnamespacesonly)	    create_namespaces_only=1			;;
 	# Object definition
 	workdir)		    common_workdir=$optvalue			;;
 	configmapfile)		    configmap_files+=("$optvalue")		;;
@@ -872,13 +860,11 @@ function process_option() {
 	containersperpod)	    containers_per_pod=$optvalue		;;
 	deploymenttype)		    deployment_type=$optvalue			;;
 	deployments|depspername*)   deps_per_namespace=$optvalue		;;
-	emptydir)		    emptydirs+=("$optvalue")			;;
-	volumes)		    emptydir_volumes=$optvalue			;;
 	exitatend)		    exit_at_end=$(bool "$optvalue")		;;
 	imagepullpolicy)	    image_pull_policy=$optvalue			;;
 	namespaces)		    namespaces=$optvalue			;;
 	nodeselector)		    node_selector=$optvalue			;;
-	volume)			    parse_volume_spec "$optvalue"		;;
+	volume)			    volumes+=("$optvalue")			;;
 	processes|processesperpod)  processes_per_pod=$optvalue			;;
 	jobfile)		    process_job_file "$optvalue"		;;
 	pinnode)		    process_pin_node "$optvalue"		;;
@@ -943,8 +929,7 @@ function process_option() {
 	vmrunascontainer)	    vm_run_as_container=$(bool "$optvalue")	;;
 	vmuser)			    vm_user=$optvalue				;;
 	vmpassword)		    vm_password=$optvalue			;;
-	vmsshpubkey)		    vm_ssh_pubkey+=("$optvalue")		;;
-	vmemptydisk*)		    process_emptydisk "$optvalue"		;;
+	vmsshkey*)		    vm_ssh_keyfile=$optvalue			;;
 	# Object creation
 	obj*spercall)		    objs_per_call=$optvalue			;;
 	parallel)		    parallel=$optvalue				;;
@@ -1018,26 +1003,20 @@ function process_job_file() {
 	fatal "Job file $jobfile cannot be read"
     fi
     while IFS= read -r line ; do
+	# shellcheck disable=SC1003
+	while [[ $line = *'\' ]] ; do
+	    line=${line::-1}
+	    local tline
+	    IFS= read -r tline
+	    [[ -z "$tline" ]] && break
+	    line+="$tline"
+	done
 	line=${line%%#*}
 	line=${line## }
 	line=${line##	}
 	if [[ -z "$line" ]] ; then continue; fi
 	process_option "$line"
     done < "$jobfile"
-}
-
-function validate_resource() {
-    local rtype=$1
-    local token
-    local status=0
-    shift
-    for token in "$@" ; do
-	if [[ $token != *'='* ]] ; then
-	    warn "Invalid $rtype specification $token (must be <resource>=<quantity>)"
-	    status=1
-	fi
-    done
-    return $status
 }
 
 ################################################################
@@ -1852,37 +1831,59 @@ function get_sync_logs_poll() {
 }
 
 function __report_one_volume() {
-    local volname=$1
-	cat <<EOF
+    local volspec=$1
+    local emptyvolid=$2
+    local -a args
+    IFS=: read -ra args <<< "$volspec"
+    local name=${args[0]}
+    local type=${args[1],,}
+    if [[ ($type = emptydisk && $runtime_class != vm) ||
+	      ($type = emptydir && $runtime_class = vm) ]] ; then
+	return 0
+    fi
+    local mountpoint=${args[2]}
+    args=("${args[@]:3}")
+    [[ $type = pvc ]] && type=persistentvolumeclaim
+    cat <<EOF
  {
-  "name": "$volname",
-  "mount_path": "${volume_mount_paths[$volname]}",
-  "type": "${volume_types[$vname]}",
-  "type_key": "${volume_types[$vname]}",
-  "scoped_name": "${volume_scoped_names[$vname]}"
+  "name": "name",
+  "mount_path": "mountpoint",
+  "type": "$type",
+  "options": {
+EOF
+    local opt
+    local value
+    local -a all_options
+    for arg in "${args[@]}" ; do
+	IFS='=' read -r opt value <<< "$arg"
+	all_options+=("\"$opt\": \"$value\"")
+    done
+    (IFS=$','; echo "${options[*]}")
+    cat <<EOF
+  }
  }
 EOF
+    if [[ $type = 'empty'* ]] ; then
+	return 2
+    else
+	return 1
+    fi
 }
 
 function _report_volumes() {
     echo '"volumes": ['
+    local vol
     local -a vols=()
-    for volname in "${volumes[@]}" ; do
-	vols+=("$(__report_one_volume "$volname")")
+    local -i emptyvolid=0
+    for volspec in "${volumes[@]}" ; do
+	vol="$(__report_one_volume "$volspec" "$emptyvolid")"
+	[[ $? = 2 ]] && emptyvolid=$((emptyvolid+1))
+	if [[ -n "$vol" ]] ; then
+	    vols+=("$vol")
+	fi
     done
     (IFS=$',\n'; echo "${vols[*]}")
     echo '],'
-}
-
-function _report_emptydirs() {
-    if ((${#emptydirs[@]})) ; then
-	echo '"emptydirVolumes": ['
-	local -a ed=("${emptydirs[@]}")
-	ed=("${ed[@]/#/}")
-	ed=("${ed[@]/%/}")
-	(IFS=$',\n'; echo "${ed[*]}")
-	echo "],"
-    fi
 }
 
 function quote_list() {
@@ -2042,7 +2043,6 @@ $(indent 2 _report_liveness_probe)
   "node_selector": "$node_selector",
 $(indent 2 container_resources_json)
   "runtime_classes": {$(_report_runtime_classes)},
-$(indent 2 _report_emptydirs)
   "target_data_rate": $target_data_rate,
   "workload_options": {
 $(indent 3 call_api -w "$requested_workload" "report_options")
@@ -2159,6 +2159,13 @@ function _retrieve_artifacts() {
 	    }
 	    unset "jobs_pending[$job]"
 	done
+	if [[ $deployment_type = vm && -f "$VIRTCTL" && -f "$vm_ssh_keyfile" ]] ; then
+	    [[ ! -d "$artifactdir/VMLogs" ]] && mkdir "$artifactdir/VMLogs"
+	    while read -r namespace vm ; do
+		# virtctl scp assumes that any colons in the destination filename are remote.
+		"$VIRTCTL" scp -i "$vm_ssh_keyfile" -t "-oStrictHostKeyChecking=no" -t "-oGlobalKnownHostsFile=/dev/null" -t "-oUserKnownHostsFile=/dev/null" -t "-oLogLevel ERROR" "$vm.$namespace:/var/log/cloud-init-output.log" "$artifactdir/VMLogs/$namespace.$vm" </dev/null && mv "$artifactdir/VMLogs/$namespace.$vm" "$artifactdir/VMLogs/$namespace:$vm"
+	    done <<< "$(__OC get vm -A -l "${basename}-id=$uuid" --no-headers | awk '{print $1, $2}')"
+	fi
 	if ((failcount > 5)) ; then
 	    echo "+ $((failcount - 5)) more" 1>&2
 	fi
@@ -2629,10 +2636,19 @@ EOF
 }
 
 function volume_mounts_yaml() {
+    local OPTIND=0
+    local use_extra_volumes=1
+    while getopts V opt "$@" ; do
+	case "$opt" in
+	    V) use_extra_volumes=0 ;;
+	    *)			   ;;
+	esac
+    done
+    shift $((OPTIND-1))
     local namespace=$1
     local deployment=${2:-1}
     local secrets=${3:-1}
-    (( secrets + ${#emptydirs[@]} + ${#configmap_files[@]} + ${#volumes[@]} + has_system_configmap + has_user_configmap )) || return;
+    (( secrets + ${#configmap_files[@]} + ${#volumes[@]} + has_system_configmap + has_user_configmap )) || return;
     local -i i
     echo volumeMounts:
     for ((i = 0; i < secrets; i++)) ; do
@@ -2643,30 +2659,12 @@ function volume_mounts_yaml() {
   readOnly: true
 EOF
     done
-    if [[ -n "${emptydirs[*]:-}" ]] ; then
-	local vol
-	for vol in "${emptydirs[@]}" ; do
-	    cat <<EOF
-- name: ${vol##*/}
-  mountPath: "$vol"
-EOF
-	done
-    fi
     if [[ ($namespace != "$sync_namespace" || $sync_in_first_namespace -ne 0) && $has_user_configmap -ne 0 ]] ; then
 	cat <<EOF
 - name: "userconfigmap-${namespace}"
   mountPath: "${user_configmap_mount_dir}"
   readOnly: true
 EOF
-    fi
-    if [[ -n "${volumes[*]:-}" ]] ; then
-	local vol
-	for vol in "${volumes[@]:-}" ; do
-	    cat <<EOF
-- name: "$vol"
-  mountPath: "${volume_mount_paths[$vol]}"
-EOF
-	done
     fi
     if (( has_system_configmap )) ; then
 	cat <<EOF
@@ -2675,6 +2673,53 @@ EOF
   readOnly: true
 EOF
     fi
+    if ((use_extra_volumes)) ; then
+	local volspec
+	local -i emptyvolid=0
+	for volspec in "${volumes[@]}" ; do
+	    local -a args
+	    IFS=: read -ra args <<< "$volspec"
+	    local name=${args[0]}
+	    local type=${args[1]}
+	    local mountpoint=${args[2]}
+
+	    args=("${args[@]:3}")
+	    case "${type,,}" in
+		emptydir)
+		    name=cbemptydir$((emptyvolid++))
+		    cat <<EOF
+- name: $name
+  mountPath: "$mountpoint"
+EOF
+		    ;;
+		pvc|persistentvolumeclaim)
+		    cat <<EOF
+- name: $name
+  mountPath: "$mountpoint"
+EOF
+		    ;;
+		*)
+		    continue
+		    ;;
+	    esac
+	done
+    fi
+}
+
+function list_volume_mount_points() {
+    local volspec
+    for volspec in "${volumes[@]}" ; do
+	local name
+	local type
+	local mountpoint
+	local args
+	read -r name type mountpoint <<< "$volspec"
+	if [[ ($type = emptydisk && $runtime_class != vm) ||
+		  ($type = emptydir && $runtime_class = vm) ]] ; then
+	    continue
+	fi
+	echo "$mountpoint"
+    done
 }
 
 function namespace_yaml() {
@@ -2722,20 +2767,102 @@ function standard_pod_metadata_yaml() {
 
 function expand_volume() {
     local scoped_name=$1
-    local namespace=${2:+-$2}
-    local instance=${3:+-$3}
+    local namespace=${2:+$2}
+    local instance=${3:+$3}
+    local replica=${4:+$4}
     scoped_name=${scoped_name//%N/$namespace}
     scoped_name=${scoped_name//%i/$instance}
+    scoped_name=${scoped_name//%r/$replica}
     echo "$scoped_name"
 }
 
+function extra_volumes_yaml() {
+    local volspec
+    local -i emptyvolid=0
+    local opt
+    local value
+    for volspec in "${volumes[@]}" ; do
+	local -a args
+	IFS=: read -ra args <<< "$volspec"
+	local name=${args[0]}
+	local type=${args[1]}
+	local mountpoint=${args[2]}
+	args=("${args[@]:3}")
+	case "${type,,}" in
+	    pvc|persistentvolumeclaim)
+		local claim_name="$name"
+		local arg
+		local size=
+		for arg in "${args[@]}" ; do
+		    IFS='=' read -r opt value <<< "$arg"
+		    case "${opt,,}" in
+			claimname) claim_name="$value"   	 ;;
+			size)	   size="$(parse_size "$value")" ;;
+			*)					 ;;
+		    esac
+		done
+		claim_name=$(expand_volume "$claim_name" "$namespace" "$instance" "$replica")
+		cat <<EOF
+- name: $name
+  persistentVolumeClaim:
+    claimName: $claim_name
+${size:+    capacity: "$size"}
+EOF
+		;;
+	    emptydisk)
+		[[ ${runtime_class:-} != vm ]] && continue
+		local arg
+		local size=
+		for arg in "${args[@]}" ; do
+		    local opt
+		    local value
+		    IFS='=' read -r opt value <<< "$arg"
+		    case "${opt,,}" in
+			size)	   size="$(parse_size "$value")" ;;
+			*)					 ;;
+		    esac
+		done
+		name="cbemptydisk$((emptyvolid++))"
+		cat <<EOF
+- name: $name
+  emptyDisk:
+    capacity: "$size"
+EOF
+		;;
+	    emptydir)
+		[[ $runtime_class = vm ]] && continue
+		name="cbemptydir$((emptyvolid++))"
+		cat <<EOF
+- name: $name
+  emptydDir: {}
+EOF
+		;;
+	    *)  ;;
+	esac
+    done
+}
+
 function volumes_yaml() {
+    local OPTIND=0
+    local -i print_volumes=-1
+    local opt
+    local -i use_extra_volumes=1
+    while getopts 'ynV' opt ; do
+	case "$opt" in
+	    y) print_volumes=1     ;;
+	    n) print_volumes=0	   ;;
+	    V) use_extra_volumes=0 ;;
+	    *)		           ;;
+	esac
+    done
+    shift $((OPTIND-1))
     local namespace=$1
     local instance=${2:-1}
     local secrets=${3:-1}
-    (( secrets + ${#emptydirs[@]} + ${#configmap_files[@]} + ${#volumes[@]} + has_system_configmap + has_user_configmap )) || return;
+    (( print_volumes > 0)) && echo "volumes:"
+    (( secrets + ${#configmap_files[@]} + ${#volumes[@]} + has_system_configmap + has_user_configmap )) || return;
     local -i i
-    echo "volumes:"
+    (( print_volumes < 0)) && echo "volumes:"
     for ((i = 0; i < secrets; i++)) ; do
 	local name="secret-${namespace}-${instance}-$i"
 	cat<<EOF
@@ -2744,40 +2871,12 @@ function volumes_yaml() {
     secretName: $name
 EOF
     done
-
-    if [[ -n "${emptydirs[*]:-}" ]] ; then
-	local vol
-	for vol in "${emptydirs[@]}" ; do
-	    cat <<EOF
-- name: ${vol##*/}
-  emptydDir: {}
-EOF
-	done
-    fi
     if [[ ($namespace != "$sync_namespace" || $sync_in_first_namespace -ne 0) && $has_user_configmap -ne 0 ]] ; then
 	cat <<EOF
 - name: "userconfigmap-${namespace}"
   configMap:
     name: "userconfigmap-${namespace}"
 EOF
-    fi
-    if [[ -n "${volumes[*]:-}" ]] ; then
-	local vol
-	for vol in "${volumes[@]:-}" ; do
-	    cat <<EOF
-- name: "$vol"
-EOF
-	    if [[ -n "${volume_type_keys[$vol]}" ]] ; then
-		cat <<EOF
-  ${volume_types[$vol]}:
-    ${volume_type_keys[$vol]}: "$(expand_volume "${volume_scoped_names[$vol]}" "$namespace" "$instance")"
-EOF
-	    else
-		cat <<EOF
-  ${volume_types[$vol]}: {}
-EOF
-	    fi
-	done
     fi
     if (( has_system_configmap )) ; then
 	cat <<EOF
@@ -2787,6 +2886,7 @@ EOF
 EOF
 
     fi
+    ((use_extra_volumes)) && extra_volumes_yaml
 }
 
 function create_affinity_yaml() {
@@ -2985,7 +3085,10 @@ function create_namespace() {
 	return 1
     fi
     if ((use_namespaces)) ; then
-	namespace_exists "$namespace" || create_object $force -t namespace "$namespace" <<EOF 2>&1
+	local -i ns_exists=0
+	namespace_exists "$namespace" && ns_exists=1
+	((ns_exists && remove_namespaces == -1)) && remove_namespaces=0
+	((ns_exists)) || create_object $force -t namespace "$namespace" <<EOF 2>&1
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -3162,7 +3265,8 @@ function create_spec() {
     local scheduler_name
     local node_selector=$node_selector
     local replica=0
-    while getopts "A:c:r:s:E:PpR:" opt "$@" ; do
+    local use_extra_volumes=
+    while getopts "A:c:r:s:E:PpR:V" opt "$@" ; do
 	case "$opt" in
 	    A) affinity_yaml=$OPTARG ;;
 	    c) node_class=$OPTARG    ;;
@@ -3172,6 +3276,7 @@ function create_spec() {
 	    R) replica=$OPTARG	     ;;
 	    P)			     ;;
 	    p)			     ;;
+	    V) use_extra_volumes=-V  ;;
 	    *)                       ;;
 	esac
     done
@@ -3201,6 +3306,7 @@ function create_spec() {
     if [[ $runtime_class = runc ]] ; then
 	runtime_class=
     fi
+    # shellcheck disable=SC2046
     cat <<EOF
 spec:
   terminationGracePeriodSeconds: 1
@@ -3210,7 +3316,7 @@ ${runtime_class:+$(indent 2 <<< "runtimeClassName: \"$runtime_class\"")}
 ${affinity_yaml:+$(indent 2 <<< "$affinity_yaml")}
   containers:
 $(indent 2 "$create_container_function" -R "$replica" "$@")
-$(indent 2 volumes_yaml "$namespace" "$instance" "$secret_count")
+$(indent 2 volumes_yaml $use_extra_volumes "$namespace" "$instance" "$secret_count")
 EOF
 }
 
@@ -3235,6 +3341,92 @@ $(indent 2 standard_pod_metadata_yaml "$namespace" client)
 $(indent 2 standard_labels_yaml -c "$node_class" -l "$workload" "$namespace" "${instance}" "${replica}")
 $(create_spec -A "$affinity_yaml" -c "$node_class" ${scheduler:+-E "$scheduler"} -R "$replica" "$@")
   restartPolicy: Never
+EOF
+    done
+}
+
+function vm_volume_devices_yaml() {
+    local volspec
+    local -i emptydiskid=0
+    for volspec in "${volumes[@]}" ; do
+	local -a args
+	IFS=: read -ra args <<< "$volspec"
+	local name=${args[0]}
+	local type=${args[1]}
+	local mountpoint=${args[2]}
+	[[ ${type,,} = emptydir ]] && continue
+	args=("${args[@]:3}")
+	local opt
+	local value
+	local bus=virtio
+	local cache=
+	local arg
+	for arg in "${args[@]}" ; do
+	    IFS='=' read -r opt value <<< "$arg"
+	    case "$opt" in
+		bus)   bus="$value"   ;;
+		cache) cache="$value" ;;
+		*)		      ;;
+	    esac
+	done
+	[[ "${type,,}" = emptydisk ]] && name="cbemptydisk$((emptydiskid++))"
+	cat <<EOF
+- name: $name
+  serial: $name
+  disk:
+    bus: $bus
+${cache:+    cache: $cache}
+EOF
+    done
+}
+
+function vm_volume_mounts_yaml() {
+    local volspec
+    local -i emptydiskid=0
+    for volspec in "${volumes[@]}" ; do
+	IFS=: read -ra args <<< "$volspec"
+	local name=${args[0]}
+	local type=${args[1]}
+	local mountpoint=${args[2]}
+	[[ ${type,,} = emptydir ]] && continue
+	args=("${args[@]:3}")
+	local mountopts=
+	local fstype
+	if [[ ${type,,} = emptydisk ]] ; then
+	    fstype=ext4
+	else
+	    fstype=
+	fi
+	local fsopts=
+	local bus=virtio
+	local inodes=
+	for arg in "${args[@]}" ; do
+	    local opt
+	    local value
+	    IFS='=' read -r opt value <<< "$arg"
+	    case "$opt" in
+		bus)	   bus="$value"	      ;;
+		inodes)    inodes="$value"    ;;
+		mountopts) mountopts="$value" ;;
+		fstype)    fstype="$value"    ;;
+		fsopts)    fsopts="$value"    ;;
+		*)			      ;;
+	    esac
+	done
+	[[ "${type,,}" = emptydisk ]] && name="cbemptydisk$((emptydiskid++))"
+	name="${bus}-${name}"
+	if [[ -n "$fstype" ]] ; then
+	    local sinodes=
+	    [[ $fstype = ext* ]] && sinodes=${inodes:+"-N '$inodes'"}
+	    local force=
+	    [[ $fstype = xfs ]] && force=-f
+	    # shellcheck disable=SC2016
+	    command="'mkfs.${fstype}' $force $sinodes $fsopts '/dev/disk/by-id/$name' && "
+	fi
+	command+="mkdir -p '$mountpoint' && mount $mountopts '/dev/disk/by-id/$name' '$mountpoint' && chmod 777 '$mountpoint'"
+	set +x
+	cat <<EOF
+- "$command"
 EOF
     done
 }
@@ -3298,7 +3490,7 @@ function create_vm_deployment() {
 			local contents
 			read -r contents < "$file"
 			cat <<EOF
-- "echo '$contents' > \"$HOME/.ssh/${file##*/}\" && chmod 644 \"$HOME/.ssh/${file##*/}\""
+- "echo '$contents' >> \"$HOME/.ssh/authorized_keys\" && chmod 600 \"$HOME/.ssh/authorized_keys\""
 EOF
 			;;
 		    *)
@@ -3308,67 +3500,6 @@ EOF
 		warn "$file does not exist or is not a plain file"
 	    fi
 	done
-    }
-    function create_emptydisk_volumes() {
-	local -i id
-	if [[ -n "${vm_emptydisk_list[*]}" ]] ; then
-	    for ((id = 0; i < ${#vm_emptydisk_list[@]}; i++)) ; do
-		local mountpoint=${vm_emptydisk_list[$id]}
-		cat << EOF
-- name: emptydisk-${id}
-  emptyDisk:
-    capacity: "${vm_emptydisks[$mountpoint]}"
-EOF
-	    done
-	fi
-    }
-    function create_emptydisk_devices() {
-	local -i id
-	if [[ -n "${vm_emptydisk_list[*]}" ]] ; then
-	    for ((id = 0; id < ${#vm_emptydisk_list[@]}; id++)) ; do
-		local mountpoint=${vm_emptydisk_list[$id]}
-		local -a emptydisk_args=()
-		IFS=: read -ra emptydisk_args <<< "${vm_emptydisk_options[$mountpoint]}"
-		local arg=
-		local cache=
-		for arg in "${emptydisk_args[@]}" ; do
-		    if [[ $arg = "cache="* ]] ; then
-			cache="  cache: ${arg/cache=/}"
-		    fi
-		done
-		cat << EOF
-- name: emptydisk-${id}
-  disk:
-    bus: virtio
-$cache
-EOF
-	    done
-	fi
-    }
-    function create_emptydisk_mounts() {
-	local -i id
-	if [[ -n "${vm_emptydisk_list[*]}" ]] ; then
-	    for ((id = 0; id < ${#vm_emptydisk_list[@]}; id++)) ; do
-		local device="/dev/vd${vm_emptydisk_suffixes:$id:1}"
-		local mountpoint=${vm_emptydisk_list[$id]}
-		local mountopts=
-		local fs=ext4
-		local fsopts=
-		local -a emptydisk_args=()
-		IFS=: read -ra emptydisk_args <<< "${vm_emptydisk_options[$mountpoint]}"
-		for arg in "${emptydisk_args[@]}" ; do
-		    case "$arg" in
-			"mountopts="*) mountopts="${arg/mountopts=/-o }";;
-			"fstype="*)    fs="${arg/fstype=/}"		;;
-			"fsopts="*)    fsopts="${arg/fsopts=/}"		;;
-			*)						;;
-		    esac
-		done
-		cat <<EOF
-- "'mkfs.$fs' $fsopts '$device' && mkdir -p '$mountpoint' && mount $mountopts '$device' '$mountpoint' && chmod 777 '$mountpoint'"
-EOF
-	    done
-	fi
     }
     get_sysctls
     local node_class=client
@@ -3428,7 +3559,7 @@ $(indent 6 vm_evict_strategy)
             - name: containerdisk
               disk:
                 bus: virtio
-$(indent 12 create_emptydisk_devices)
+$(indent 12 vm_volume_devices_yaml)
             - name: systemconfigmap-${namespace}
               serial: systemconfigmap
               volumeName: systemconfigmap-${namespace}
@@ -3439,16 +3570,10 @@ $(indent 8 container_resources_yaml)
       terminationGracePeriodSeconds: $vm_grace_period
 $(indent 6 <<< "$affinity_yaml")
       volumes:
+$(indent 8 volumes_yaml -n "$namespace" "$instance" "$secret_count")
         - name: containerdisk
           containerDisk:
             image: $vm_image
-$(indent 8 create_emptydisk_volumes)
-        - name: systemconfigmap-${namespace}
-          configMap:
-            name: systemconfigmap-${namespace}
-        - name: userconfigmap-${namespace}
-          configMap:
-            name: userconfigmap-${namespace}
         - name: cloudinitdisk
           cloudInitNoCloud:
             userData: |-
@@ -3459,10 +3584,10 @@ $(indent 8 create_emptydisk_volumes)
               chpasswd: { expire: False }
               bootcmd:
                 - "mkdir '$system_configmap_mount_dir' '$user_configmap_mount_dir'"
-$(indent 16 create_emptydisk_mounts)
+$(indent 16 vm_volume_mounts_yaml)
                 - "mount -o ro /dev/disk/by-id/ata-QEMU_HARDDISK_systemconfigmap '$system_configmap_mount_dir'"
                 - "mount -o ro /dev/disk/by-id/ata-QEMU_HARDDISK_userconfigmap '$user_configmap_mount_dir'"
-$(indent 16 insert_ssh_keys "${vm_ssh_pubkey[@]}")
+$(indent 16 insert_ssh_keys "${vm_ssh_keyfile}.pub")
                 $(install_required_packages)
 $(indent 16 setup_commands)
 $(indent 16 setup_sysctls)
@@ -3588,7 +3713,6 @@ function create_generic_deployment() {
     done
 }
 
-
 function create_container_sync() {
     local OPTARG
     local OPTIND=0
@@ -3623,7 +3747,7 @@ $(indent 2 standard_environment)
   - "$sync_ns_port"
   - "$expected_clients"
   - "$initial_expected_clients"
-$(indent 2 volume_mounts_yaml "$namespace" 0 0)
+$(indent 2 volume_mounts_yaml -V "$namespace" 0 0)
 $(indent 2 restricted_security_context)
 EOF
 }
@@ -3644,7 +3768,7 @@ $(indent 2 standard_labels_yaml -c sync -S -t 'sync' 'sync' "${basename}-sync")
   selector:
     matchLabels:
       app: ${namespace}
-$(create_container_function=create_container_sync create_spec -P -s '' -c sync -r '' "$namespace" 0 0 "$@")
+$(create_container_function=create_container_sync create_spec -V -P -s '' -c sync -r '' "$namespace" 0 0 "$@")
 $(indent 2 <<< "$affinity_yaml")
   restartPolicy: Never
 EOF
@@ -3690,7 +3814,7 @@ $(indent 2 standard_environment)
   - "$sync_ns_port"
   - "none"
   - "$drop_cache_port"
-$(indent 2 volume_mounts_yaml "$namespace" 0 0)
+$(indent 2 volume_mounts_yaml -V "$namespace" 0 0)
   - mountPath: "/proc-sys-vm"
     name: "proc-sys-vm"
 EOF
@@ -3716,7 +3840,7 @@ $(indent 2 standard_labels_yaml -c dc -s dc -S -t drop-cache "$workload" "$names
   selector:
     matchLabels:
       replica: ${namespace}-${workload}-${instance}-${replica}
-$(create_container_function=create_container_drop_cache create_spec -P -s '' -c drop-cache -r '' "$namespace" "$instance" 0)
+$(create_container_function=create_container_drop_cache create_spec -V -P -s '' -c drop-cache -r '' "$namespace" "$instance" 0)
   - name: "proc-sys-vm"
     hostPath:
       path: "/proc/sys/vm"
@@ -3903,16 +4027,22 @@ function create_all_objects() {
 function _do_cleanup_1() {
     local ltimeout="${force_cleanup_timeout:+--timeout=${timeout}s}"
     local force=0
+    local -i precleanup=0
     local OPTIND=0
     local opt
-    while getopts 'f' opt "$@" ; do
+    while getopts 'fp' opt "$@" ; do
 	case "$opt" in
-	    f) force=1 ;;
-	    *)         ;;
+	    f) force=1 	    ;;
+	    p) precleanup=1 ;;
+	    *)		    ;;
 	esac
     done
     shift $((OPTIND-1))
     local objects_to_clean
+    if [[ $use_namespaces -ne 0 && $precleanup -ne 0 && $remove_namespaces -eq -1 &&
+	      -n "$(__OC get ns -l "${basename}-sync" 2>/dev/null; __OC get ns -l "${basename}" 2>/dev/null)" ]] ; then
+	remove_namespaces=0
+    fi
     if ((use_namespaces && remove_namespaces)) ; then
 	objects_to_clean=ns
     else
@@ -3960,29 +4090,30 @@ function _do_cleanup() {
 function do_cleanup() {
     local force=
     local OPTIND=0
-    local -i precleanup=0
+    local precleanup=
     local opt
+    local -a args=("$@")
     while getopts 'fp' opt "$@" ; do
 	case "$opt" in
-	    f) force=-f      ;;
-	    p) precleanup=1 ;;
+	    f) force=-f     ;;
+	    p) precleanup=-p;;
 	    *)              ;;
 	esac
     done
     shift "$OPTIND"
     (( doit )) || return 0
-    if [[ -n "${injected_errors[precleanup]:-}" && $precleanup -gt 0 ]] ; then
+    if [[ -n "${injected_errors[precleanup]:-}" && $precleanup = -p ]] ; then
 	warn "*** Injecting precleanup error ${inject_errors[precleanup]:-}"
 	sleep "${injected_errors[precleanup]:-}"
 	killthemall "Cleanup timed out!"
     fi
-    if [[ -n "${injected_errors[cleanup]:-}" && $precleanup -eq 0 ]] ; then
+    if [[ -n "${injected_errors[cleanup]:-}" && $precleanup = -p ]] ; then
 	warn "*** Injecting cleanup error ${inject_errors[cleanup]:-}"
 	sleep "${injected_errors[cleanup]:-}"
 	killthemall "Cleanup timed out!"
     fi
     # shellcheck disable=SC2086
-    _do_cleanup $force || killthemall "Cleanup timed out!"
+    _do_cleanup "$@" || killthemall "Cleanup timed out!"
 }
 
 ################################################################
@@ -4132,6 +4263,13 @@ function expand_string() {
     echo "$string"
 }
 
+function setup_namespaces() {
+    allocate_namespaces || return 1
+    if [[ $sync_start -ne 0 && -n "$sync_namespace" && $sync_in_first_namespace -eq 0 ]] ; then
+	create_namespace -S -f "$sync_namespace" 1>&2 || return 1
+    fi
+}
+
 function run_clusterbuster_2() {
     local -A expected_secrets=()
     local -i status=0
@@ -4161,12 +4299,9 @@ function run_clusterbuster_2() {
 	    exec 2> >(trap '' TERM INT HUP USR1 USR2; stdbuf -i0 -o0 -e0 tee >(trap '' TERM INT HUP USR1 USR2; stdbuf -i0 -o0 -e0 tr "\r" "\n" > "$artifactdir/stderr.log") >&2)
 	fi
     fi
-    allocate_namespaces || return 1
-    find_first_deployment || return 1
-    if [[ $sync_start -ne 0 && -n "$sync_namespace" && $sync_in_first_namespace -eq 0 ]] ; then
-	create_namespace -S -f "$sync_namespace" 1>&2 || return 1
-    fi
+    setup_namespaces || return 1
     create_all_objects namespaces || return 1
+    find_first_deployment || return 1
     if get_sync -q ; then
 	if (( use_namespaces )) ; then
 	    global_sync_service="svc-${sync_namespace}-sync.${sync_namespace}.svc.cluster.local"
@@ -4197,25 +4332,29 @@ function run_clusterbuster_2() {
 function run_clusterbuster_1() {
     protect_pids "$BASHPID"
     local -i status=0
-    run_clusterbuster_2
-    status=$?
-    if (( (cleanup_always || (cleanup && status == 0)) && doit)) ; then
-	do_cleanup || {
-	    if ((status == 0)) ; then
-		status=1
-	    fi
-	}
-    fi
-
-    if ((status)) ; then
-	fatal -w "Clusterbuster failed!"
+    if ((create_namespaces_only)) ; then
+	setup_namespaces
     else
-	if [[ $take_prometheus_snapshot -gt 0 && -n "$artifactdir" ]] ; then
-	    retrieve_prometheus_snapshot "$artifactdir"
+	run_clusterbuster_2
+	status=$?
+	if (( (cleanup_always || (cleanup && status == 0)) && doit)) ; then
+	    do_cleanup || {
+		if ((status == 0)) ; then
+		    status=1
+		fi
+	    }
 	fi
+
+	if ((status)) ; then
+	    fatal -w "Clusterbuster failed!"
+	else
+	    if [[ $take_prometheus_snapshot -gt 0 && -n "$artifactdir" ]] ; then
+		retrieve_prometheus_snapshot "$artifactdir"
+	    fi
+	fi
+	get_run_failed && status=1
+	return $status
     fi
-    get_run_failed && status=1
-    return $status
 }
 
 ################################################################
@@ -4223,11 +4362,112 @@ function run_clusterbuster_1() {
 ################################################################
 
 function remove_tmpdir() {
-    [[ -n "${cb_tempdir:-}" && -d "$cb_tempdir" && $cb_tempdir = "/tmp/cbtmp_"* ]] && rm -rf "$cb_tempdir" && unset cb_tempdir
+    if [[ -n "${cb_tempdir:-}" && -d "$cb_tempdir" && $cb_tempdir = "/tmp/cbtmp_"* ]] ; then
+	if ((preserve_tmpdir)) ; then
+	    warn "*** Preserving temporary directory $cb_tempdir"
+	else
+	    rm -rf "$cb_tempdir"
+	fi
+	unset cb_tempdir
+    fi
+}
+
+function validate_resource() {
+    local rtype=$1
+    local token
+    local status=0
+    shift
+    for token in "$@" ; do
+	if [[ $token != *'='* ]] ; then
+	    warn "Invalid $rtype specification $token (must be <resource>=<quantity>)"
+	    status=1
+	fi
+    done
+    return $status
+}
+
+function validate_volumes() {
+    local -a vol_errors=()
+    local -A mount_volume_map=()
+    local -A mount_name_map=()
+    local volspec
+    for volspec in "${volumes[@]}" ; do
+	local -a args
+	IFS=: read -ra args <<< "$volspec"
+	((${#args[@]} < 3)) && vol_errors+=("Volume name, type, and mountpoint must be specified for $volspec")
+	local name="${args[0]}"
+	local type="${args[1],,}"
+	local mountpoint="${args[2]}"
+	if [[ -z "$name" && -z "$type" && -z "$mountpoint" ]] ; then
+	    mount_volume_map=()
+	    continue
+	fi
+	mount_volume_map["$mountpoint"]="$volspec"
+	mount_name_map["$mountpoint"]="$name"
+	# Remove a mountpoint from the list
+	[[ -z "$type" ]] && continue
+	args=("${args[@]:3}")
+	case "${type}" in
+	    pvc|persistentvolumeclaim)
+		[[ -z "$name" ]] && warn "Name ignored for PVC: $volspec"
+		;;
+	    emptydisk|emptydir)
+		[[ -n "$name" ]] && warn "Name ignored for $type volume: $volspec"
+		;;
+	    *)
+		fatal "Unknown volume type $type"
+		;;
+	esac
+	local -i size=
+	for arg in "${args[@]}" ; do
+	    if [[ $arg != *'='* ]] ; then
+		vol_errors+=("Cannot parse volume argument $arg from $volspec")
+	    fi
+	    local opt
+	    local value
+	    IFS='=' read -r opt value <<< "$arg"
+	    case "${opt,,}" in
+		size)
+		    size=$(parse_size "$value") || vol_errors+=("Cannot parse size $value for $volspec")
+		    ((size <= 0)) && vol_errors+=("Volume size must be greater than zero for $volspec")
+		    ;;
+		*)
+		    ;;
+	    esac
+	done
+	if [[ $type = emptydisk && (-z "$size" || $size -le 0) ]] ; then
+	    vol_errors+=("Positive size must be provided for emptydisk volumes ($volspec)")
+	fi
+    done
+    local -A used_names=()
+    local name
+    for name in "${mount_name_map[@]}" ; do
+	if [[ -n "$name" && -n "${used_names[$name]:-}" ]] ; then
+	    vol_errors+=("Duplicate volume name $name")
+	fi
+	used_names[$name]=1
+    done
+    local nvolumes=()
+    local -A used_volumes=()
+    for volspec in "${volumes[@]}" ; do
+	local -a args
+	IFS=: read -ra args <<< "$volspec"
+	local mountpoint="${args[2]}"
+	if [[ -z "${used_volumes[$mountpoint]:-}" && $volspec = "${mount_volume_map[$mountpoint]}" ]] ; then
+	    used_volumes[$mountpoint]=1
+	    nvolumes+=("$volspec")
+	fi
+    done
+    if [[ -n "${vol_errors[*]}" ]] ; then
+	local errstr
+	errstr=$(IFS=$'\n'; echo -e "The following errors occurred while validating volumes:\n${vol_errors[*]}")
+	fatal "$errstr"
+    fi
+    volumes=("${nvolumes[@]}")
 }
 
 function validate_options() {
-    [[ -z "$requested_workload" ]] && help "Workload must be specified with --workload"fi
+    [[ -z "$requested_workload" ]] && help "Workload must be specified with --workload"
 
     local iworkload=$requested_workload
     requested_workload=$(get_workload "$requested_workload") || help_extended "(Unknown workload '$iworkload')"
@@ -4271,15 +4511,13 @@ function validate_options() {
 	    if ((containers_per_pod > 1)) ; then
 		help "ERROR: containers_per_pod must equal 1 for vm deployments"
 	    fi
-	    deployment_type=vm                                           ;;
+	    deployment_type=vm
+	    runtime_class=vm
+	    ;;
 	*)
 	    help "--deployment_type must be pod, vm, deployment, or replicaset"
+	    ;;
     esac
-    if [[ ${deployment_type,,} != vm ]] ; then
-	vm_emptydisk_list=()
-	vm_emptydisks=()
-	vm_emptydisk_options=()
-    fi
 
     [[ -z "$OC" && $doit -gt 0 ]] && fatal "Cannot find oc or kubectl command, exiting!"
 
@@ -4288,20 +4526,28 @@ function validate_options() {
     validate_resource resource_limit "${resource_limits[@]}" || resource_validation_failed=1
     ((resource_validation_failed)) && exit 1
 
-    for ((i = 0; i < emptydir_volumes; i++)) ; do
-	emptydirs+=("/mnt/volume-$i")
-    done
+    validate_volumes
 
     job_name=${job_name:-${requested_workload:-}}
 
-    if [[ ${runtime_class:-} = "$kata_runtime_class" ]] ; then
-	((virtiofsd_direct)) && virtiofsd_args+=('"-o"' '"allow_direct_io"')
-	((virtiofsd_writeback)) && virtiofsd_args+=('"-o"' '"writeback"')
-	((virtiofsd_threadpoolsize)) && virtiofsd_args+=("\"--thread-pool-size=$virtiofsd_threadpoolsize\"")
-	if [[ -n "${virtiofsd_args[*]:-}" ]] ; then
-	    pod_annotations+=("io.katacontainers.config.hypervisor.virtio_fs_extra_args: '[$(IFS=,; echo "${virtiofsd_args[*]}")]'")
-	fi
-    fi
+    case "$runtime_class" in
+	vm)
+	    if [[ -z "$vm_ssh_keyfile" ]] ; then
+		ssh-keygen -C '' -t "$ssh_alg" -q -f "$cb_tempdir/id_${ssh_alg}" -N ''
+		vm_ssh_keyfile="$cb_tempdir/id_${ssh_alg}"
+	    fi
+	    ;;
+	kata)
+	    ((virtiofsd_direct)) && virtiofsd_args+=('"-o"' '"allow_direct_io"')
+	    ((virtiofsd_writeback)) && virtiofsd_args+=('"-o"' '"writeback"')
+	    ((virtiofsd_threadpoolsize)) && virtiofsd_args+=("\"--thread-pool-size=$virtiofsd_threadpoolsize\"")
+	    if [[ -n "${virtiofsd_args[*]:-}" ]] ; then
+		pod_annotations+=("io.katacontainers.config.hypervisor.virtio_fs_extra_args: '[$(IFS=,; echo "${virtiofsd_args[*]}")]'")
+	    fi
+	    ;;
+	*)
+	    ;;
+    esac
     if ((pod_start_timeout < 0)) ; then
 	if [[ $deployment_type = vm ]] ; then
 	    pod_start_timeout=$default_vm_start_timeout
@@ -4321,7 +4567,7 @@ load_workloads "$CB_LIBPATH"
 
 set_metrics_file default
 
-while getopts ":B:Eef:Hhno:P:w:Qqv-:" opt ; do
+while getopts ":B:Eef:Hhno:P:w:QqvN-:" opt ; do
     case "$opt" in
 	B) process_option "basename=$OPTARG"	 ;;
 	E) process_option "exit_at_end=0"	 ;;
@@ -4329,6 +4575,7 @@ while getopts ":B:Eef:Hhno:P:w:Qqv-:" opt ; do
 	f) process_job_file "$OPTARG"		 ;;
 	h) help					 ;;
 	H) help_extended			 ;;
+	N) process_option "createnamespacesonly=1";;
 	n) process_option "doit=0"		 ;;
 	o) process_option "reportformat=$OPTARG" ;;
 	P) process_option "workload=$OPTARG"     ;;

--- a/docs/clusterbuster.md
+++ b/docs/clusterbuster.md
@@ -512,9 +512,9 @@ To create a new workload, you need to do the following:
 ### Create A Deployment Type
 
 Clusterbuster currently supports running workloads as pods,
-ReplicaSets, or Deployments (with very minimal differences between the
-latter two).  At present, the object types are hard-coded into
-Clusterbuster; at some point I intend to refactor those.
+ReplicaSets, Deployments, or VMs (with very minimal differences
+between the latter two).  At present, the object types are hard-coded
+into Clusterbuster; at some point I intend to refactor those.
 
 All of the object types are created from `create_standard_deployment`,
 which dispatches to the appropriate object creation based on the value

--- a/lib/clusterbuster/CI/profiles/func_ci.profile
+++ b/lib/clusterbuster/CI/profiles/func_ci.profile
@@ -33,3 +33,7 @@ use-python-venv=1
 cleanup=1
 restart=0
 deployment-type=replicaset
+
+volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
+volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/perf_ci.profile
+++ b/lib/clusterbuster/CI/profiles/perf_ci.profile
@@ -34,3 +34,7 @@ use-python-venv=1
 cleanup=1
 restart=0
 deployment-type=replicaset
+
+volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
+volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/release.profile
+++ b/lib/clusterbuster/CI/profiles/release.profile
@@ -38,3 +38,7 @@ restart=0
 use-python-venv=1
 cleanup=1
 deployment-type=replicaset
+
+volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
+volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/test_ci.profile
+++ b/lib/clusterbuster/CI/profiles/test_ci.profile
@@ -34,3 +34,7 @@ use-python-venv=1
 cleanup=1
 restart=0
 deployment-type=replicaset
+
+volume:files,fio:pod,kata=:emptydir:/var/tmp/clusterbuster
+volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:fstype=ext4:size=auto:inodes=auto
+volume:fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.workload
@@ -57,24 +57,19 @@ function cpusoaker_test_1() {
 
 function cpusoaker_test() {
     local default_job_runtime=$1
-    if ((___cpusoaker_replica_increment < 1)) ; then
-	echo "Replica increment must be at least 1" 1>&2
-	return
-    fi
-    if ((___cpusoaker_job_runtime <= 0)) ; then
-	___cpusoaker_job_runtime=$default_job_runtime
-    fi
-    ___cpusoaker_job_timeout=$(compute_timeout "$___cpusoaker_job_timeout")
     local -A runtimes_tested=()
     local runtime
     for runtime in "${runtimeclasses[@]}" ; do
-	local xruntime=${runtime:-runc}
-	if [[ -z "${runtimes_tested[$xruntime]:-}" ]] ; then
-	    if [[ $runtime = runc ]] || check_runtimeclass "$xruntime" >/dev/null 2>&1 ; then
-		runtimes_tested[$xruntime]=1
-		cpusoaker_test_1 "$runtime"
-	    fi
+	process_workload_options "$workload" "${runtimeclass:-pod}"
+	if ((___cpusoaker_replica_increment < 1)) ; then
+	    echo "Replica increment must be at least 1" 1>&2
+	    return 1
 	fi
+	if ((___cpusoaker_job_runtime <= 0)) ; then
+	    ___cpusoaker_job_runtime=$default_job_runtime
+	fi
+	___cpusoaker_job_timeout=$(compute_timeout "$___cpusoaker_job_timeout")
+	cpusoaker_test_1 "$runtime"
     done
 }
 
@@ -89,9 +84,13 @@ function cpusoaker_initialize_options() {
 
 function cpusoaker_process_option() {
     local opt=$1
-    read -r noptname1 noptname optvalue workload <<< "$(parse_option -w "$opt")"
-    [[ -n "$workload" && $workload != cpusoaker ]] && return 2
+    local noptname1
+    local noptname
+    local optvalue
+    # shellcheck disable=SC2034
+    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     case "$noptname1" in
+	'')		    						;;
 	cpusoakerstarting*) ___cpusoaker_starting_replicas=$optvalue	;;
 	cpusoakerreplicai*) ___cpusoaker_replica_increment=$optvalue	;;
 	cpusoaker*runtime)  ___cpusoaker_job_runtime=$optvalue		;;

--- a/lib/clusterbuster/CI/workloads/files.workload
+++ b/lib/clusterbuster/CI/workloads/files.workload
@@ -24,6 +24,7 @@ declare -gi ___files_job_timeout
 declare -ga ___files_params
 declare -gi ___files_min_direct
 declare -gi ___files_drop_cache
+declare -ga ___files_volumes
 
 function files_test() {
     function roundup() {
@@ -31,59 +32,87 @@ function files_test() {
 	local -i interval=$2
 	echo $((((base + interval - 1) / interval) * interval))
     }
-    ___files_job_timeout=$(compute_timeout "$___files_job_timeout")
-    if [[ -z "${___files_params[*]}" ]] ; then
-	for ninst in "${___files_ninst[@]}" ; do
-	    for dirs in "${___files_dirs_per_volume[@]}" ; do
-		for files in "${___files_per_dir[@]}" ; do
-		    for blocksize in "${___files_block_sizes[@]}" ; do
-			for size in "${___files_sizes[@]}" ; do
-			    for direct in "${___files_directs[@]}" ; do
-				if ((! direct || blocksize >= ___files_min_direct)) ; then
-				    ___files_params+=("${ninst}:${dirs}:${files}:${blocksize}:${size}:${direct}")
-				fi
+    for runtimeclass in "${runtimeclasses[@]}" ; do
+	process_workload_options "$workload" "${runtimeclass:-pod}"
+	___files_job_timeout=$(compute_timeout "$___files_job_timeout")
+	if [[ -z "${___files_params[*]}" ]] ; then
+	    for ninst in "${___files_ninst[@]}" ; do
+		for dirs in "${___files_dirs_per_volume[@]}" ; do
+		    for files in "${___files_per_dir[@]}" ; do
+			for blocksize in "${___files_block_sizes[@]}" ; do
+			    for size in "${___files_sizes[@]}" ; do
+				for direct in "${___files_directs[@]}" ; do
+				    if ((! direct || blocksize >= ___files_min_direct)) ; then
+					___files_params+=("${ninst}:${dirs}:${files}:${blocksize}:${size}:${direct}")
+				    fi
+				done
 			    done
 			done
 		    done
 		done
 	    done
+	fi
+	local -i ninst
+	local ___files_dirs_per_volume
+	local ___files_per_dir
+	local ___files_block_size
+	local file_size
+	local ___files_direct
+	local options
+	local counter=0
+	for options in "${___files_params[@]}" ; do
+	    read -r ninst ___files_dirs_per_volume ___files_per_dir ___files_block_size file_size ___files_direct <<< "$(parse_size -n "${options//:/ }")"
+	    if [[ -z "$___files_direct" ]] ; then
+		echo "Unparsable options $options" 1>&2
+		continue
+	    fi
+	    if ((___files_block_size > file_size && file_size > 0)) ; then
+		___files_block_size=$file_size
+	    fi
+	    local -i fs_block_size=4096 # Need a better way than hard coding this; assumes ext4
+	    local -i inode_size_bytes=256 # Need a better way than hard coding this; assumes ext4
+	    job_name="${ninst}P-${___files_dirs_per_volume}D-${___files_per_dir}F-${___files_block_size}B-${file_size}S-${___files_direct}T"
+	    local -i bytes_per_file=file_size
+	    if ((bytes_per_file < fs_block_size)) ; then bytes_per_file=fs_block_size; fi
+	    bytes_per_file=$(roundup "$bytes_per_file" "$fs_block_size")
+	    local -i inodes_required=$((1024 + ___files_dirs_per_volume + (___files_dirs_per_volume * ___files_per_dir)))
+	    local -i bytes_required=$(((inodes_required * 256) + (bytes_per_file * ___files_dirs_per_volume * ___files_per_dir)))
+	    # Add 12.5% overhead and round up to next MB
+	    bytes_required=$(roundup $((bytes_required * 9 / 8)) 1048576)
+	    ((bytes_required < 32 * 1048576)) && bytes_required=$((32 * 1048576))
+	    # shellcheck disable=SC2090
+	    local -a nvolumes=()
+	    local volspec
+	    for volspec in "${___files_volumes[@]}" ; do
+		local arg
+		local -a args=()
+		local -a nargs=()
+		local -a fsopts=()
+		IFS=: read -ra args <<< "$volspec"
+		for arg in "${args[@]}" ; do
+		    # shellcheck disable=SC2206
+		    case "$arg" in
+			size=auto*)   nargs+=("size=$bytes_required")   ;;
+			inodes=auto*) nargs+=("inodes=$inodes_required");;
+			fsopts=*)     fsopts+=(${arg/fsopts=/})	        ;;
+			*)	      nargs+=("$arg")		        ;;
+		    esac
+		done
+		[[ -n "${fsopts[*]}" ]] && nargs+=("fsopts=${fsopts[*]}")
+		nvolumes+=("--volume=$(IFS=:; echo "${nargs[*]}")")
+	    done
+
+	    run_clusterbuster_1 -r "$runtimeclass" \
+				-j "$job_name" -w files -t "$___files_job_timeout" -- \
+				--replicas="$ninst" \
+				--dirs_per_volume="$___files_dirs_per_volume" \
+				--files_per_dir="$___files_per_dir" \
+				--file_block_size="$___files_block_size" \
+				--files_direct="$___files_direct" \
+				--filesize="$file_size" \
+				"${nvolumes[@]}"
+	    counter=$((counter+1))
 	done
-    fi
-    local -i ninst
-    local ___files_dirs_per_volume
-    local ___files_per_dir
-    local ___files_block_size
-    local file_size
-    local ___files_direct
-    local options
-    for options in "${___files_params[@]}" ; do
-	read -r ninst ___files_dirs_per_volume ___files_per_dir ___files_block_size file_size ___files_direct <<< "$(parse_size -n "${options//:/ }")"
-	if [[ -z "$___files_direct" ]] ; then
-	    echo "Unparsable options $options" 1>&2
-	    continue
-	fi
-	if ((___files_block_size > file_size && file_size > 0)) ; then
-	    ___files_block_size=$file_size
-	fi
-	local -i fs_block_size=4096 # Need a better way than hard coding this; assumes ext4
-	local -i inode_size_bytes=256 # Need a better way than hard coding this; assumes ext4
-	local -i bytes_per_file=file_size
-	if ((bytes_per_file < fs_block_size)) ; then bytes_per_file=fs_block_size; fi
-	bytes_per_file=$(roundup "$bytes_per_file" "$fs_block_size")
-	local -i inodes_required=$((1024 + ___files_dirs_per_volume + (___files_dirs_per_volume * ___files_per_dir)))
-	local -i bytes_required=$(((inodes_required * 256) + (bytes_per_file * ___files_dirs_per_volume * ___files_per_dir)))
-	# Add 12.5% overhead and round up to next MB
-	bytes_required=$(roundup $((bytes_required * 9 / 8)) 1048576)
-	job_name="${ninst}P-${___files_dirs_per_volume}D-${___files_per_dir}F-${___files_block_size}B-${file_size}S-${___files_direct}T"
-	# shellcheck disable=SC2090
-	run_clusterbuster -j "$job_name" -w files -t "$___files_job_timeout" -- \
-			  --replicas="$ninst" \
-			  --dirs_per_volume="$___files_dirs_per_volume" \
-			  --files_per_dir="$___files_per_dir" \
-			  --file_block_size="$___files_block_size" \
-			  --files_direct="$___files_direct" \
-			  --filesize="$file_size" \
-			  --vm-emptydisk="$bytes_required:fsopts=-N ${inodes_required}:/var/tmp"
     done
 }
 
@@ -98,13 +127,19 @@ function files_initialize_options() {
     ___files_params=()
     ___files_min_direct=1024
     ___files_drop_cache=1
+    ___files_volumes=()
 }
 
 function files_process_option() {
     local opt=$1
-    read -r noptname1 noptname optvalue workload <<< "$(parse_option -w "$opt")"
-    [[ -n "$workload" && $workload != files ]] && return 2
+    local noptname1
+    local noptname
+    local optvalue
+    # shellcheck disable=SC2034
+    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    # shellcheck disable=SC2206
     case "$noptname1" in
+	'')		 									;;
 	filesninst*)     readarray -t ___files_ninst <<< "$(parse_size "$optvalue")"		;;
 	filesdirs*)	 readarray -t ___files_dirs_per_volume <<< "$(parse_size "$optvalue")"	;;
 	filesperdir*)    readarray -t ___files_per_dir <<< "$(parse_size "$optvalue")"		;;
@@ -115,6 +150,7 @@ function files_process_option() {
 	files*params)    ___files_params+=(${optvalue//,/ })					;;
 	filesmindir*)    ___files_min_direct=$(parse_size "$optvalue")				;;
 	filesdrop*)	 ___files_drop_cache=$(bool "$optvalue")				;;
+	volume)		 ___files_volumes+=("$optvalue")					;;
 	*) 		 return 1								;;
     esac
 }
@@ -122,6 +158,7 @@ function files_process_option() {
 function files_help_options() {
     cat <<EOF
     Files test options:
+    	The files
         --files-timeout=seconds
                                 Time the job out after specified time.  Default
                                 is the global timeout default.

--- a/lib/clusterbuster/CI/workloads/fio.workload
+++ b/lib/clusterbuster/CI/workloads/fio.workload
@@ -31,52 +31,99 @@ declare -gi ___fio_ramptime
 declare -gi ___fio_job_timeout
 declare -gi ___fio_drop_cache
 declare -gi ___fio_pod_memsize
-declare -gi ___fio_use_emptydisk
+declare -ga ___fio_volumes=()
 
 function fio_test() {
+    function roundup() {
+	local num=${1:-1}
+	local base=${2:-1048576}
+	local answer=$((((num + (base - 1)) / base) * base))
+	((answer <= 0)) && answer=$base
+	echo "$answer"
+    }
+
     local default_job_runtime=$1
-    if ((___fio_job_runtime <= 0)) ; then
-	___fio_job_runtime=$default_job_runtime
-    fi
-    ___fio_job_timeout=$(compute_timeout "$___fio_job_timeout")
-    if ((___fio_absolute_filesize <= 0 || ___fio_max_absolute_filesize <= 0)) ; then
-	local ___fio_node_memory=
-	___fio_node_memory=$(get_node_memory "$client_pin_node") || fatal "Cannot retrieve node memory."
-	if ((___fio_absolute_filesize <= 0)) ; then
-	    ___fio_absolute_filesize=$(computeit "$___fio_node_memory * $___fio_relative_filesize")
-	fi
-	if ((___fio_max_absolute_filesize <= 0)) ; then
-	    ___fio_max_absolute_filesize=$(computeit "$___fio_node_memory * $___fio_max_relative_filesize")
-	fi
-    fi
     local -i ninst
-    local memory_annotation=
-    if ((___fio_pod_memsize > 0)) ; then
-	# shellcheck disable=SC2089
-	memory_annotation=--pod-annotation="io.katacontainers.config.hypervisor.default_memory: \"$___fio_pod_memsize\""
-    fi
-    for ninst in "${___fio_ninst[@]}" ; do
-	local filesize
-	filesize=$(computeit "$___fio_absolute_filesize / $ninst")
-	if ((filesize > ___fio_max_absolute_filesize)) ; then
-	    filesize=$___fio_max_absolute_filesize
-	fi
-	job_name="${ninst}P"
-	# shellcheck disable=SC2090
-	run_clusterbuster -j "$job_name" -w fio -t "$___fio_job_timeout" -R "$___fio_job_runtime" -- \
-			  --replicas="$ninst" \
-			  --fio-blocksize="$(IFS=,; echo "${___fio_blocksizes[*]}")" \
-			  --fio-patterns="$(IFS=,; echo "${___fio_patterns[*]}")" \
-			  --fio-ioengines="$(IFS=,; echo "${___fio_ioengines[*]}")" \
-			  --fio-iodepths="$(IFS=,; echo "${___fio_iodepths[*]}")" \
-			  --fio-fdatasyncs="$(IFS=,; echo "${___fio_fdatasyncs[*]}")" \
-			  --fio-directs="$(IFS=,; echo "${___fio_directs[*]}")" \
-			  --fio_filesize="$filesize" \
-			  --fio_ramp_time="$___fio_ramptime" \
-			  --fio_workdir="$___fio_workdir" \
-			  --fio-drop-cache="$___fio_drop_cache" \
-			  --vm-emptydisk="$(((((___fio_absolute_filesize * 11 / 10) + 1048575) / 1048576) * 1048576)):/var/tmp" \
-			  ${memory_annotation:+"$memory_annotation"}
+    # shellcheck disable=SC2090
+    for runtimeclass in "${runtimeclasses[@]}" ; do
+	process_workload_options "$workload" "${runtimeclass:-pod}"
+	local -i counter=0
+	for ninst in "${___fio_ninst[@]}" ; do
+	    if ((___fio_job_runtime <= 0)) ; then
+		___fio_job_runtime=$default_job_runtime
+	    fi
+	    ___fio_job_timeout=$(compute_timeout "$___fio_job_timeout")
+	    if ((___fio_absolute_filesize <= 0 || ___fio_max_absolute_filesize <= 0)) ; then
+		local ___fio_node_memory=
+		___fio_node_memory=$(get_node_memory "$client_pin_node") || fatal "Cannot retrieve node memory."
+		if ((___fio_absolute_filesize <= 0)) ; then
+		    ___fio_absolute_filesize=$(computeit "$___fio_node_memory * $___fio_relative_filesize")
+		fi
+		if ((___fio_max_absolute_filesize <= 0)) ; then
+		    ___fio_max_absolute_filesize=$(computeit "$___fio_node_memory * $___fio_max_relative_filesize")
+		fi
+	    fi
+	    local memory_annotation=
+	    if ((___fio_pod_memsize > 0)) && [[ $runtimeclass = kata ]] ; then
+		# shellcheck disable=SC2089
+		memory_annotation=--pod-annotation="io.katacontainers.config.hypervisor.default_memory: \"$___fio_pod_memsize\""
+	    fi
+	    local filesize
+	    filesize=$(computeit "$___fio_absolute_filesize / $ninst")
+	    if ((filesize > ___fio_max_absolute_filesize)) ; then
+		filesize=$___fio_max_absolute_filesize
+	    fi
+	    job_name="${ninst}P"
+	    local -a nvolumes=()
+	    local volspec
+	    for volspec in "${___fio_volumes[@]}" ; do
+		local arg
+		local -a args=()
+		local -a nargs=()
+		IFS=: read -ra args <<< "$volspec"
+		for arg in "${args[@]}" ; do
+		    case "$arg" in
+			size=auto*)
+			    if [[ $arg =~ size=auto(,([0-9]+[a-zA-Z]*))? ]] ; then
+				local vsize
+				vsize=${BASH_REMATCH[1]}
+				if [[ -n "$vsize" ]] ; then
+				    vsize=$(parse_size "$vsize")
+				else
+				    vsize=$((filesize * 9 / 8))
+				fi
+				vsize=$(roundup "$(parse_size "$vsize")")
+				nargs+=("size=$vsize")
+			    else
+				nargs+=("$arg")
+			    fi
+			    ;;
+			inodes=*)
+			    ;;
+			*)
+			    nargs+=("$arg")
+			    ;;
+		    esac
+		done
+		nvolumes+=("--volume=$(IFS=:; echo "${nargs[*]}")")
+	    done
+	    run_clusterbuster_1 -r "$runtimeclass" \
+				-j "$job_name" -w fio -t "$___fio_job_timeout" -R "$___fio_job_runtime" -- \
+				--replicas="$ninst" \
+				--fio-blocksize="$(IFS=,; echo "${___fio_blocksizes[*]}")" \
+				--fio-patterns="$(IFS=,; echo "${___fio_patterns[*]}")" \
+				--fio-ioengines="$(IFS=,; echo "${___fio_ioengines[*]}")" \
+				--fio-iodepths="$(IFS=,; echo "${___fio_iodepths[*]}")" \
+				--fio-fdatasyncs="$(IFS=,; echo "${___fio_fdatasyncs[*]}")" \
+				--fio-directs="$(IFS=,; echo "${___fio_directs[*]}")" \
+				--fio_filesize="$filesize" \
+				--fio_ramp_time="$___fio_ramptime" \
+				--fio_workdir="$___fio_workdir" \
+				--fio-drop-cache="$___fio_drop_cache" \
+				"${nvolumes[@]}" \
+				${memory_annotation:+"$memory_annotation"}
+	    counter=$((counter+1))
+	done
     done
 }
 
@@ -89,7 +136,7 @@ function fio_initialize_options() {
     ___fio_ioengines=(sync libaio)
     ___fio_ninst=(1 4)
     ___fio_job_runtime=0
-    ___fio_workdir=/var/tmp
+    ___fio_workdir=/var/tmp/clusterbuster
     ___fio_absolute_filesize=0
     ___fio_max_absolute_filesize=0
     ___fio_relative_filesize=2
@@ -98,14 +145,18 @@ function fio_initialize_options() {
     ___fio_job_timeout=9000
     ___fio_drop_cache=1
     ___fio_pod_memsize=
-    ___fio_use_emptydisk=1
+    ___fio_volumes=()
 }
 
 function fio_process_option() {
     local opt=$1
-    read -r noptname1 noptname optvalue workload <<< "$(parse_option -w "$opt")"
-    [[ -n "$workload" && $workload != fio ]] && return 2
+    local noptname1
+    local noptname
+    local optvalue
+    # shellcheck disable=SC2034
+    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     case "$noptname1" in
+	'')		 								;;
 	fioblock*)       readarray -t ___fio_blocksizes <<< "$(parse_size "$optvalue")"	;;
 	fiopat*)         readarray -t ___fio_patterns <<< "${optvalue//,/ }"		;;
 	fiodirect*)      readarray -t ___fio_directs <<< "$(bool "$optvalue")"		;;
@@ -123,6 +174,7 @@ function fio_process_option() {
 	fio*timeout)     ___fio_job_timeout=$optvalue					;;
 	fiodrop*)	 ___fio_drop_cache=$(bool "$optvalue")				;;
 	fio*memsize)     ___fio_pod_memsize=$(parse_size "$optvalue")			;;
+	volume)		 ___fio_volumes+=("$optvalue")					;;
 	*) 		 return 1							;;
     esac
 }
@@ -130,6 +182,8 @@ function fio_process_option() {
 function fio_help_options() {
     cat <<EOF
    Fio test options:
+        There should be sufficient space under the work directory to hold the desired file
+        size, provided if need be by a volume.
         --fio-block-sizes=n[,n...]
                                 Space or comma separated list of block
                                 sizes to test.  Default is $(IFS=,; echo "${___fio_blocksizes[*]}").

--- a/lib/clusterbuster/CI/workloads/uperf.workload
+++ b/lib/clusterbuster/CI/workloads/uperf.workload
@@ -27,31 +27,38 @@ declare -g ___uperf_use_annotation
 
 function uperf_test() {
     local default_job_runtime=$1
-    if ((___uperf_job_runtime <= 0)) ; then
-	___uperf_job_runtime=$default_job_runtime
-    fi
-    ___uperf_job_timeout=$(compute_timeout "$___uperf_job_timeout")
+    local runtimeclass
+    for runtimeclass in "${runtimeclasses[@]}" ; do
+	process_workload_options "$workload" "${runtimeclass:-pod}"
+	if ((___uperf_job_runtime <= 0)) ; then
+	    ___uperf_job_runtime=$default_job_runtime
+	fi
+	___uperf_job_timeout=$(compute_timeout "$___uperf_job_timeout")
 
-    local -i msg_size
-    local -i nthr
-    local -i ninst
-    local test_type
-    for msg_size in "${___uperf_msg_sizes[@]}" ; do
-	for nthr in "${___uperf_nthrs[@]}" ; do
-	    for ninst in "${___uperf_ninst[@]}" ; do
-		for test_type in "${___uperf_test_types[@]}" ; do
-		    local job_name="${msg_size}B-${nthr}i-${ninst}P-${test_type}"
-		    run_clusterbuster -j "$job_name" -w uperf -t "$___uperf_job_timeout" -R "$___uperf_job_runtime" -- \
-				      --replicas="$ninst" \
-				      --uperf_msg_size="$msg_size" \
-				      --uperf_test_type="$test_type" \
-				      --uperf_proto=tcp \
-				      --uperf_nthr="$nthr" \
-				      ${uperf_interface:+--uperf_interface=$___uperf_interface:} \
-				      ${uperf_interface_server:+--uperf_interface_server=$___uperf_interface_server:} \
-				      ${uperf_interface_client:+--uperf_interface_client=$___uperf_interface_client:} \
-				      --uperf_interface="$___uperf_interface" \
-				      ${___uperf_use_annotation:+--pod-annotation="io.katacontainers.config.hypervisor.default_vcpus: \"$nthr\""}
+	local -i msg_size
+	local -i nthr
+	local -i ninst
+	local test_type
+	local counter=0
+	for msg_size in "${___uperf_msg_sizes[@]}" ; do
+	    for nthr in "${___uperf_nthrs[@]}" ; do
+		for ninst in "${___uperf_ninst[@]}" ; do
+		    for test_type in "${___uperf_test_types[@]}" ; do
+			local job_name="${msg_size}B-${nthr}i-${ninst}P-${test_type}"
+			run_clusterbuster_1 -r "$runtimeclass" \
+					    -j "$job_name" -w uperf -t "$___uperf_job_timeout" -R "$___uperf_job_runtime" -- \
+					    --replicas="$ninst" \
+					    --uperf_msg_size="$msg_size" \
+					    --uperf_test_type="$test_type" \
+					    --uperf_proto=tcp \
+					    --uperf_nthr="$nthr" \
+					    ${uperf_interface:+--uperf_interface=$___uperf_interface:} \
+					    ${uperf_interface_server:+--uperf_interface_server=$___uperf_interface_server:} \
+					    ${uperf_interface_client:+--uperf_interface_client=$___uperf_interface_client:} \
+					    --uperf_interface="$___uperf_interface" \
+					    ${___uperf_use_annotation:+--pod-annotation="io.katacontainers.config.hypervisor.default_vcpus: \"$nthr\""}
+			counter=$((counter+1))
+		    done
 		done
 	    done
 	done
@@ -73,9 +80,13 @@ function uperf_initialize_options() {
 
 function uperf_process_option() {
     local opt=$1
-    read -r noptname1 noptname optvalue workload <<< "$(parse_option -w "$opt")"
-    [[ -n "$workload" && $workload != uperf ]] && return 2
+    local noptname1
+    local noptname
+    local optvalue
+    # shellcheck disable=SC2034
+    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     case "$noptname1" in
+	'')	       										;;
 	uperfmsg*)     readarray -t ___uperf_msg_sizes <<< "$(parse_size "$optvalue")"		;;
 	uperfnthr*)    readarray -t ___uperf_nthrs <<< "$(parse_size "$optvalue")"		;;
 	uperfninst*)   readarray -t ___uperf_ninst <<< "$(parse_size "$optvalue")"		;;

--- a/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
+++ b/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
@@ -181,7 +181,7 @@ class ClusterBusterReporter:
                 jdata = item
             else:
                 raise ClusterBusterUnrecognizedItemException(f"Unrecognized item {item}")
-            answers.append(ClusterBusterReporter.report_one("N/A", jdata, report_format, extras=extras))
+            answers.append(ClusterBusterReporter.report_one(None, jdata, report_format, extras=extras))
         return answers
 
     @staticmethod

--- a/lib/clusterbuster/reporting/reporting_exceptions.py
+++ b/lib/clusterbuster/reporting/reporting_exceptions.py
@@ -15,4 +15,4 @@
 
 class ClusterBusterReportingException(Exception):
     def __init__(self, *args):
-        super().__init__('\n'.join(list(*args)))
+        super().__init__('\n'.join([str(arg) for arg in args]))

--- a/lib/clusterbuster/workloads/byo.workload
+++ b/lib/clusterbuster/workloads/byo.workload
@@ -20,7 +20,7 @@
 
 declare -ag ___byo_args=()
 declare -ag ___byo_files=()
-declare -g ___byo_workdir=/var/tmp/cb-work
+declare -g ___byo_workdir=/var/tmp/clusterbuster/cb-work
 declare -g ___byo_workload=
 declare -g ___byo_name=
 declare -ig ___byo_drop_cache=0
@@ -100,14 +100,6 @@ function byo_workload_reporting_class() {
 }
 
 function byo_report_options() {
-    function mk_str_list() {
-	local _strings=()
-	local _arg
-	for _arg in "$@" ; do
-	    _strings+=("\"$_arg\"")
-	done
-	echo "[$(IFS=','; echo "${_strings[*]}")]"
-    }
     cat <<EOF
 "byo_workload": "$___byo_workload",
 "byo_workdir": "$___byo_workdir",

--- a/lib/clusterbuster/workloads/cpusoaker.workload
+++ b/lib/clusterbuster/workloads/cpusoaker.workload
@@ -31,4 +31,4 @@ function cpusoaker_document() {
 EOF
 }
 
-register_workload cpusoaker cpu cpusoak 
+register_workload cpusoaker cpu cpusoak

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -23,7 +23,8 @@ declare -ig ___file_block_size=0
 declare -ig ___file_dirs_per_volume=1
 declare -ig ___files_per_dir=1
 declare -ig ___files_direct=0
-declare -ig  ___files_drop_cache=1
+declare -ig ___files_drop_cache=1
+declare -ia ___file_dirs=()
 
 function files_create_deployment() {
     create_generic_deployment -p "$@"
@@ -40,10 +41,9 @@ function files_arglist() {
     local dc_port=0
     while [[ "$1" != '--' ]] ; do shift; done; shift
     local -i file_blocks=$((___file_size/___file_block_size))
-    local mounts=("${volume_mount_paths[@]}" "${emptydirs[@]}" "${vm_emptydisk_list[@]}")
     mk_yaml_args "python3" "${mountdir}files.py" "$@" \
 		 "$___file_dirs_per_volume" "$___files_per_dir" "$___file_block_size" "$file_blocks" \
-		 "$processes_per_pod" "$___files_direct" "${mounts[@]}"
+		 "$processes_per_pod" "$___files_direct" "${___files_dirs[@]}"
 }
 
 function files_help_options() {
@@ -87,6 +87,13 @@ function files_process_options() {
 	    filesize)		___file_size=$(parse_size "$optvalue")		;;
 	    filesdirect)	___files_direct=$(bool "$optvalue")		;;
 	    filesdrop*)		___files_drop_cache=$(bool "$optvalue")	 	;;
+	    filesdir*)
+		if [[ -z "$optvalue" ]] ; then
+		    ___files_dirs=()
+		else
+		    ___files_dirs+=("$optvalue")
+		fi
+		;;
 	    *) 			unknown_opts+=("$noptname ($noptname1)") 	;;
 	esac
     done
@@ -96,6 +103,7 @@ function files_process_options() {
     if (( ___file_block_size <= 0)) ; then
 	___file_block_size=___file_size
     fi
+    [[ -z "${___files_dirs[*]}" ]] && ___files_dirs=(/var/tmp/clusterbuster)
 }
 
 function files_requires_drop_cache() {
@@ -113,7 +121,8 @@ function files_report_options() {
 "file_block_size": $___file_block_size,
 "file_size": $___file_size,
 "files_direct": $___files_direct,
-"files_drop_cache": $___files_drop_cache
+"files_drop_cache": $___files_drop_cache,
+"files_dirs": $(mk_str_list "${___files_dirs[@]}")
 EOF
 }
 

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -28,7 +28,7 @@ declare -ag ___fio_ioengines=(libaio)
 declare -g  ___fio_job_file=generic.jobfile
 declare -gi ___fio_ramp_time=5
 declare -gi ___fio_filesize=; ___fio_filesize=$(parse_size "4Gi")
-declare -g  ___fio_workdir="/tmp"
+declare -g  ___fio_workdir="/var/tmp/clusterbuster"
 declare -g  ___fio_processed_job_file
 declare -ig  ___fio_drop_cache=1
 
@@ -212,18 +212,6 @@ EOF
 }
 
 function fio_report_options() {
-    function mk_num_list() {
-	echo "[$(IFS=','; echo "$*")]"
-    }
-    function mk_str_list() {
-	local _strings=()
-	local _arg
-	for _arg in "$@" ; do
-	    _strings+=("\"$_arg\"")
-	done
-	echo "[$(IFS=','; echo "${_strings[*]}")]"
-    }
-
     cat <<EOF
 "fio_options": "${___fio_options:-}",
 "fio_job_file": "$(base64 -w 0 < "$___fio_processed_job_file")",

--- a/prom-extract
+++ b/prom-extract
@@ -15,34 +15,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-import sys
-import time
-import os
-from datetime import datetime, timezone, timedelta
-import json
-import subprocess
-import urllib3
-import uuid
-import yaml
-try:
-    from prometheus_api_client import PrometheusConnect
-    import argparse
-    from jinja2 import Template
-    import selectors
-except ModuleNotFoundError as exc:
-    print(f"prom-extract failed: {exc}", file=sys.stderr)
-    print("{}")
-    sys.exit(1)
-
-# Both openshift and openshift_client provide packages named openshift.
-# Make sure that we have the correct one.
-try:
-    import openshift
-    _ = openshift.project
-except (ModuleNotFoundError, AttributeError) as exc:
-    print(f"prom-extract failed: {exc} (need to install 'openshift_client', not 'openshift')", file=sys.stderr)
-    print("{}")
-    sys.exit(1)
 
 
 def eprint(*args, **kwargs):
@@ -51,7 +23,38 @@ def eprint(*args, **kwargs):
 
 def efail(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
+    print("{}")
     sys.exit(1)
+
+
+try:
+    from prometheus_api_client import PrometheusConnect
+    import argparse
+    from jinja2 import Template
+    import selectors
+    import sys
+    import time
+    import os
+    from datetime import datetime, timezone, timedelta
+    import json
+    import subprocess
+    import urllib3
+    import uuid
+    import yaml
+except (KeyboardInterrupt, BrokenPipeError):
+    efail('')
+except ModuleNotFoundError as exc:
+    efail(f"prom-extract failed: {exc}")
+
+# Both openshift and openshift_client provide packages named openshift.
+# Make sure that we have the correct one.
+try:
+    import openshift
+    _ = openshift.project
+except (KeyboardInterrupt, BrokenPipeError):
+    efail('')
+except (ModuleNotFoundError, AttributeError) as exc:
+    efail(f"prom-extract failed: {exc} (need to install Python 'openshift_client', not 'openshift')")
 
 
 def run_command(cmd, fail_on_bad_status=True, report_stderr_async=True,
@@ -98,7 +101,7 @@ def get_prometheus_default_url():
         with openshift.project('openshift-monitoring'):
             return 'https://%s' % openshift.selector(['route/prometheus-k8s']).objects()[0].as_dict()['spec']['host']
     except (KeyboardInterrupt, BrokenPipeError):
-        sys.exit()
+        efail('')
     except Exception as err:
         efail("Unable to retrieve prometheus-k8s route: %s" % err)
 
@@ -116,7 +119,7 @@ def get_prometheus_token():
     try:
         return 'Bearer %s' % get_prometheus_token_by_version()
     except (KeyboardInterrupt, BrokenPipeError):
-        sys.exit()
+        efail('')
     except Exception as err:
         efail("Unable to retrieve prometheus-k8s token: %s" % err)
 
@@ -131,7 +134,7 @@ def get_prometheus_timestamp():
                                                                                      container_name='prometheus')
                 return datetime.utcfromtimestamp(float(result.out()))
         except (KeyboardInterrupt, BrokenPipeError):
-            sys.exit()
+            efail('')
         except Exception as err:
             if retries <= 0:
                 efail("Unable to retrieve date: %s" % err)
@@ -143,7 +146,7 @@ def get_nodes():
     try:
         return json.loads([n.as_dict() for n in openshift.selector(['node']).objects()])
     except (KeyboardInterrupt, BrokenPipeError):
-        sys.exit()
+        efail('')
     except Exception as err:
         efail("Unable to retrieve cluster version: %s" % err)
 
@@ -221,6 +224,8 @@ try:
                 yaml = yaml.safe_load(yamltxt)
         except FileNotFoundError as err:
             efail(f'Cannot open metrics profile: {err}')
+    except (KeyboardInterrupt, BrokenPipeError):
+        efail('')
     except Exception as err:
         efail(f'Cannot load metrics definition: {err}')
 
@@ -246,8 +251,8 @@ try:
                         readline = sys.stdin.readline()
                 for line in _read_stdin():
                     stdout_data.append([datetime.now(timezone.utc).isoformat(), line.decode().rstrip()])
-        except KeyboardInterrupt:
-            efail("Interrupted")
+        except (KeyboardInterrupt, BrokenPipeError):
+            efail('')
         except Exception as err:
             efail(err)
         endTime = get_prometheus_timestamp()
@@ -257,9 +262,9 @@ try:
             try:
                 json_output = json.loads("\n".join(a[1] for a in stdout_data))
             except (KeyboardInterrupt, BrokenPipeError):
-                sys.exit()
+                efail('')
             except json.decoder.JSONDecodeError as err:
-                eprint("Cannot decode command output as JSON: %s" % err)
+                efail("Cannot decode command output as JSON: %s" % err)
 
         json_results = {}
         json_api_objects = []
@@ -282,9 +287,13 @@ try:
                                     apiobj = get_object(api_object['kind'], api_object['name'])
                                     if apiobj is not None:
                                         json_api_objects.append(apiobj)
+                                except (KeyboardInterrupt, BrokenPipeError):
+                                    efail('')
                                 except Exception as get_err:
                                     eprint("Unable to retrieve object %s/%s in namespace %s: %s" %
                                            (api_object['kind'], api_object['name'], api_object['namespace'], get_err))
+                        except (KeyboardInterrupt, BrokenPipeError):
+                            efail('')
                         except Exception as ns_err:
                             eprint("Unable to set namespace %s: %s" % (api_object['namespace'], ns_err))
                 del json_output['api_objects']
@@ -312,6 +321,8 @@ try:
                                                       end_time=metricsEndTime, step=args.step)
             else:
                 metric_data = prom.custom_query(metric['query'])
+        except (KeyboardInterrupt, BrokenPipeError):
+            efail('')
         except Exception as err:
             eprint(f"Query {metric['metricName']} ({metric['query']}) failed: {err}")
         name = metric['query']
@@ -352,6 +363,9 @@ try:
             if stdout_data:
                 results['rundata']['stdout'] = stdout_data
 
-    json.dump(results, indent=args.indent, fp=sys.stdout)
+    s = json.dumps(results, indent=args.indent)
+    print(s)
 except (KeyboardInterrupt, BrokenPipeError):
-    sys.exit(1)
+    efail('')
+except Exception as exc:
+    efail(f"prom-extract failed: {exc}")


### PR DESCRIPTION
- Eliminate --emptydirs and --emptydir (specify volumes explicitly)
- Fix option parsing for where there may be spaces in option values
- Allow specifying conditional workloads and runtimeclasses for run-perf-ci-suite
- Add pre-run and post-run script for run-perf-ci-suite
- Use volumes for files and fio
- Allow specifying auto volume size for files and fio
- Use /var/tmp/clusterbuster as the default work directory
- Correctly inject ssh keys into VM
- Generate a temporary ssh key if none provided with --ssh-keyfile
- Retrieve logs from VMs
- Rework the perf CI argument parsing logic to avoid having to change the clusterbuster arg parsing.
- Allow the stack trace to be used from all libclusterbuster.sh clients.
- Don't add a -N <inodes> argument to non-ext4 filesystems.
- Treat no successful jobs from the CI suite as failure.
- Tighten up exception handling in prom-extract.
- Only delete namespaces by default if we created all of our namespaces.
- Check for duplicate volume names
- Add --preserve-tmpdir to retain the temporary directory for debugging.