### PR TITLE
Miscellaneous fixes/minor improvements:

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -504,7 +504,7 @@ $(list_profiles '                                - ')
                                 distinct string to aid in later identification.
 
     All other options listed below may be of the form
-    --option:<workload><runtime>=value to specify that the value should apply
+    --option:<workload>:<runtime>=value to specify that the value should apply
     only to a particular workload and runtimeclass.  Either workload or
     runtimeclass may be omitted or be of the form
     :workload
@@ -639,6 +639,8 @@ function test_parse() {
 
 function check_clusterbuster_option() {
     local option=$1
+    option=${option//-/}
+    option=${option//_/}
     if [[ -z "${known_clusterbuster_options[*]}" ]] ; then
 	local arg
 	while read -r arg ; do
@@ -704,16 +706,12 @@ function process_workload_options() {
 	local optvalue
 	local optworkload
 	# shellcheck disable=SC2034
-	read -r noptname1 noptname optvalue <<< "$(parse_option "$option" "$workload" "$runtimeclass")"
+	read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$option" "$workload" "$runtimeclass")"
 	if [[ -n "$noptname1" ]] ; then
 	    optvalue=$(splitarg "$optvalue")
-	    if ! call_api -A -a -w "$workload" process_option "$option" ; then
-		if check_clusterbuster_option "$noptname1" ; then
-		    extra_clusterbuster_args+=("--$noptname=$optvalue")
-		else
-		    stack_trace
-		    fatal "Unknown option $option ($noptname1)"
-		fi
+	    if ! call_api -a -w "$workload" process_option "$option" &&
+		    check_clusterbuster_option "$noptname1" ; then
+		extra_clusterbuster_args+=("--$noptname=$optvalue")
 	    fi
 	fi
     done

--- a/clusterbuster
+++ b/clusterbuster
@@ -498,27 +498,30 @@ $(print_workloads_supporting_reporting '                        - ')
                         - mount_path is the path on which to mount the volume
                             (required).
                         Options currently supported include the following:
-                           - claimName is the name of a PVC if it differs
-                             from the volume name.  This allows use of
-                             different PVCs; all occurrences of %N
-                             are replaced by the namespace of the pod
-                             mounting the volume; all instances of %i
-                             are replaced by the instance of the pod
-                             within the namespace.
-                           - size in bytes (required for emptydisk; ignored for
-                             other volume types).
-                           - inodes in number (optional for emptydisk; ignored
-                             for other volume types).
-                           - bus (VMs; ignored for pods): bus to be used
-                             for the volume (default virtio)
-                           - cache (VMs): caching mode (none, writeback,
-                             writethrough; default none)
-                           - fstype (VMs): filesystem type to format
-                             the volume to; empty means to not format
-                             the volume (filesystem must already be present).
-                             fsopts (VMs): options to use for formatting
-                             the filesystem.
-                           - mountopts (VMs): mount options to be used.
+                          - claimName is the name of a PVC if it differs
+                            from the volume name.  This allows use of
+                            different PVCs; all occurrences of %N
+                            are replaced by the namespace of the pod
+                            mounting the volume; all instances of %i
+                            are replaced by the instance of the pod
+                            within the namespace.
+                          - size in bytes (required for emptydisk; ignored for
+                            other volume types).
+                          - inodes in number (optional for emptydisk; ignored
+                            for other volume types).
+                          - bus (VMs; ignored for pods): bus to be used
+                            for the volume (default virtio)
+                          - cache (VMs): caching mode (none, writeback,
+                            writethrough; default none)
+                          - fstype (VMs): filesystem type to format
+                            the volume to; empty means to not format
+                            the volume (filesystem must already be present).
+                            fsopts (VMs): options to use for formatting
+                            the filesystem.
+                          - mountopts (VMs): mount options to be used.
+                          - nfsserv (VMs): NFS server for NFS-based PVCs.
+                          - nfsshare (VMs): NFS share name for NFS-based
+                            PVCs.  Default to '/'.                         
                         Notes:
                           - A previously declared mount can be overridden
                             by specifying a later mount with the same
@@ -1667,7 +1670,7 @@ function _fail_helper()  {
 	local podstatus
 	podstatus=$(____OC get pod -ojsonpath='{.status.phase}' "${sync_pod[@]}" 2>/dev/null)
 	case "$podstatus" in
-	    Succeeded|Terminated)
+	    Succeeded|Terminated|Completed)
 		return
 		;;
 	    Running)
@@ -1775,7 +1778,7 @@ function _get_sync_logs_poll() {
 		set_run_failed "Status of pod $pod failed!"
 		return 1
 		;;
-	    ''|Succeeded)	# Might be an old pod not yet deleted
+	    ''|Succeeded|Completed)	# Might be an old pod not yet deleted
 		if ((pod_status_found)) ; then
 		    echo "Unexpected status '$status' of pod $pod!" 1>&2
 		    return 1
@@ -2099,16 +2102,17 @@ EOF
     return $retval
 }
 
-function _describe_pod() {
+function _describe_entity() {
     local namespace=$1
-    local pod=$2
-    local poddesc="$artifactdir/Describe/${namespace}:${pod}"
-    if __OC describe pod -n "$namespace" "$pod" > "${poddesc}.tmp" ; then
-	mv "${poddesc}.tmp" "$poddesc"
-	[[ -s "$poddesc" ]] || echo "Warning: empty description for ${namespace}:${pod}" 1>&2
+    local name=$2
+    local entitytype=${3:-pod}
+    local namedesc="$artifactdir/Describe/${3:+$3+}${namespace}:${name}"
+    if __OC describe "${entitytype}" -n "$namespace" "$name" > "${namedesc}.tmp" ; then
+	mv "${namedesc}.tmp" "$namedesc"
+	[[ -s "$namedesc" ]] || echo "Warning: empty $entitytype description for ${namespace}:${name}" 1>&2
     else
-	echo "Unable to retrieve pod description for ${namespace}:${pod}" 1>&2
-	rm -f "${poddesc}.tmp"
+	echo "Unable to retrieve $entitytype description for ${namespace}:${name}" 1>&2
+	rm -f "${namedesc}.tmp"
 	false
     fi
 }
@@ -2157,10 +2161,10 @@ function _retrieve_artifacts() {
 	    local name="${podname}:${container}"
 	    if [[ -z "${pods_described[$podname]:-}" ]] ; then
 		if ((parallel_log_retrieval > 1)) ; then
-		    _describe_pod "$namespace" "$pod" &
+		    _describe_entity "$namespace" "$pod" &
 		    jobs_pending[$!]=$podname
 		else
-		    _describe_pod "$namespace" "$pod"
+		    _describe_entity "$namespace" "$pod"
 		fi
 		pods_described[$name]=1
 	    fi
@@ -2186,11 +2190,34 @@ function _retrieve_artifacts() {
 	    wait "$job" 2>/dev/null
 	    unset "jobs_pending[$job]"
 	done
+	if [[ $runtime_class = vm ]] ; then
+	    local vm
+	    local entitytype
+	    local ignore
+	    for entitytype in vm vmi ; do
+		jobs_to_wait=()
+		# shellcheck disable=SC2034
+		while read -r namespace vm ignore ; do
+		    if ((parallel_log_retrieval > 1)) ; then
+			_describe_entity "$namespace" "$vm" "$entitytype"&
+			jobs_pending[$!]=$podname
+		    else
+			_describe_entity "$namespace" "$vm" "$entitytype"
+		    fi
+		    pods_described[$name]=1
+		done <<< "$(__OC get "${entitytype}" -A -l "${basename}-id=$uuid" --no-headers 2>/dev/null)"
+		local -a jobs_to_wait=("${!jobs_pending[@]}")
+		for job in "${jobs_to_wait[@]}" ; do
+		    wait "$job" 2>/dev/null
+		    unset "jobs_pending[$job]"
+		done
+	    done
+	fi
 	if [[ $deployment_type = vm && -f "$VIRTCTL" && -f "$vm_ssh_keyfile" ]] ; then
 	    [[ ! -d "$artifactdir/VMLogs" ]] && mkdir "$artifactdir/VMLogs"
 	    while read -r namespace vm ; do
 		# virtctl scp assumes that any colons in the destination filename are remote.
-		"$VIRTCTL" scp -i "$vm_ssh_keyfile" -t "-oStrictHostKeyChecking=no" -t "-oGlobalKnownHostsFile=/dev/null" -t "-oUserKnownHostsFile=/dev/null" -t "-oLogLevel ERROR" "$vm.$namespace:/var/log/cloud-init-output.log" "$artifactdir/VMLogs/$namespace.$vm" </dev/null && mv "$artifactdir/VMLogs/$namespace.$vm" "$artifactdir/VMLogs/$namespace:$vm"
+		"$VIRTCTL" scp -i "$vm_ssh_keyfile" -t "-oStrictHostKeyChecking=no" -t "-oGlobalKnownHostsFile=/dev/null" -t "-oUserKnownHostsFile=/dev/null" -t "-oLogLevel ERROR" "root@$vm.$namespace:/var/log/cloud-init-output.log" "$artifactdir/VMLogs/$namespace.$vm" </dev/null 1>&2 && mv "$artifactdir/VMLogs/$namespace.$vm" "$artifactdir/VMLogs/$namespace:$vm"
 	    done <<< "$(__OC get vm -A -l "${basename}-id=$uuid" --no-headers | awk '{print $1, $2}')"
 	fi
     fi
@@ -3427,6 +3454,8 @@ function vm_volume_mounts_yaml() {
 	local fsopts=
 	local bus=virtio
 	local inodes=
+	local nfssrv=
+	local nfsshare=/
 	for arg in "${args[@]}" ; do
 	    local opt
 	    local value
@@ -3437,21 +3466,27 @@ function vm_volume_mounts_yaml() {
 		mountopts) mountopts="$value" ;;
 		fstype)    fstype="$value"    ;;
 		fsopts)    fsopts="$value"    ;;
+		nfssrv)    nfssrv="$value"    ;;
+		nfsshare)  nfsshare="$value"  ;;
 		*)			      ;;
 	    esac
 	done
-	[[ "${type,,}" = emptydisk ]] && name="cbemptydisk$((emptydiskid++))"
-	name="${bus}-${name}"
-	if [[ -n "$fstype" ]] ; then
-	    local sinodes=
-	    [[ $fstype = ext* ]] && sinodes=${inodes:+"-N '$inodes'"}
-	    local force=
-	    [[ $fstype = xfs ]] && force=-f
-	    # shellcheck disable=SC2016
-	    command="'mkfs.${fstype}' $force $sinodes $fsopts '/dev/disk/by-id/$name' && "
+	if [[ -n "${nfssrv}" ]] ; then
+	    local remote="${nfssrv}:${nfsshare}"
+	    command="mkdir -p '$mountpoint' && mount $mountopts '$remote' '$mountpoint' && chmod 777 '$mountpoint'"
+	else
+	    [[ "${type,,}" = emptydisk ]] && name="cbemptydisk$((emptydiskid++))"
+	    name="${bus}-${name}"
+	    if [[ -n "$fstype" ]] ; then
+		local sinodes=
+		[[ $fstype = ext* ]] && sinodes=${inodes:+"-N '$inodes'"}
+		local force=
+		[[ $fstype = xfs ]] && force=-f
+		# shellcheck disable=SC2016
+		command="'mkfs.${fstype}' $force $sinodes $fsopts '/dev/disk/by-id/$name' && "
+	    fi
+	    command+="mkdir -p '$mountpoint' && mount $mountopts '/dev/disk/by-id/$name' '$mountpoint' && chmod 777 '$mountpoint'"
 	fi
-	command+="mkdir -p '$mountpoint' && mount $mountopts '/dev/disk/by-id/$name' '$mountpoint' && chmod 777 '$mountpoint'"
-	set +x
 	cat <<EOF
 - "$command"
 EOF
@@ -3521,7 +3556,7 @@ function _insert_ssh_keys() {
 		    local contents
 		    read -r contents < "$file"
 		    cat <<EOF
-- "echo '$contents' >> \"$HOME/.ssh/authorized_keys\" && chmod 600 \"$HOME/.ssh/authorized_keys\""
+- "echo '$contents' >> \"/root/.ssh/authorized_keys\" && chmod 600 \"/root/.ssh/authorized_keys\""
 EOF
 		    ;;
 		*)

--- a/lib/clusterbuster/CI/workloads/cpusoaker.ci
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.ci
@@ -60,7 +60,7 @@ function cpusoaker_test() {
     local -A runtimes_tested=()
     local runtime
     for runtime in "${runtimeclasses[@]}" ; do
-	process_workload_options "$workload" "${runtimeclass:-pod}"
+	process_workload_options "$workload" "${runtime:-pod}"
 	if ((___cpusoaker_replica_increment < 1)) ; then
 	    echo "Replica increment must be at least 1" 1>&2
 	    return 1

--- a/lib/clusterbuster/pod_files/files.py
+++ b/lib/clusterbuster/pod_files/files.py
@@ -69,9 +69,12 @@ class files_client(clusterbuster_pod_client):
                             if answer != self.blocksize:
                                 raise os.IOError(f"Incomplete write to {filename} (file {files_created}): {answer} bytes, expect {self.blocksize}")
                             ops = ops + 1
-                        except Exception as exc:
+                        except IOError as exc:
                             raise Exception(f"Write failed to {filename} (file {files_created}): {exc}") from None
-                    os.close(fd)
+                    try:
+                        os.close(fd)
+                    except IOError as exc:
+                        raise Exception(f"Unable to close {filename} (file {files_created}): {exc}") from None
         return ops
 
     def readthem(self, pid: int, oktofail: bool = False):

--- a/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
+++ b/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
@@ -147,8 +147,6 @@ class ClusterBusterReporter:
                                                               extras=extras)
                     if report:
                         answers.append(report)
-                    answers.append(ClusterBusterReporter.report_one(os.path.dirname(item), data, report_format,
-                                                                    extras=extras))
                 except (KeyboardInterrupt, BrokenPipeError):
                     sys.exit(1)
                 except TypeError:
@@ -204,8 +202,9 @@ class ClusterBusterReporter:
     def list_report_formats():
         return ['none', 'summary', 'verbose', 'raw', 'raw-python',
                 'json-summary', 'json', 'json-verbose',
-                'parseable-summary', 'parseable-verbose',
-                'json-summary-python', 'json-python', 'json-verbose-python',
+                'parseable', 'parseable-summary', 'parseable-verbose',
+                'json-summary-python', 'json-python',
+                'json-verbose-python', 'parseable-python',
                 'parseable-summary-python', 'parseable-verbose-python'
                 ]
 
@@ -246,6 +245,10 @@ class ClusterBusterReporter:
         :param indent: Per-level indentation
         :param report_width: Width of the report
         """
+        if report_format == 'parseable':
+            report_format = 'parseable-summary'
+        if report_format == 'parseable-python':
+            report_format = 'parseable-summary-python'
         parser = argparse.ArgumentParser(description='Parse report')
         parser.add_argument('--no-summary', action='store_true', help='Do not print standard summary')
         self._base_args, self.__extra_args = parser.parse_known_args(extras)

--- a/prom-extract
+++ b/prom-extract
@@ -28,11 +28,11 @@ def efail(*args, **kwargs):
 
 
 try:
+    import sys
     from prometheus_api_client import PrometheusConnect
     import argparse
     from jinja2 import Template
     import selectors
-    import sys
     import time
     import os
     from datetime import datetime, timezone, timedelta


### PR DESCRIPTION
- Eliminate duplicate reports
- Retrieve logs for VMs in addition to pods.
- Retrieve VM logs with correct (root) username.
- Handle Completed status in fail path.
- Add NFS PVCs.
- import sys at the top of prom-extract in case a later import fails (so we can report to stderr)
- Allow report types of parseable and parseable-python as aliases for the summary versions of both.
- Check status from io.close() in the files workload
- cpusoaker CI: handle runtimeclass correctly
- Reporting: break out some generic exceptions
- Correctly handle conditional non-workload options.