### PR TITLE
Miscellaneous (mostly VM) improvements 20240403

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -62,7 +62,8 @@ declare -i debugonly=0
 declare force_cleanup_timeout=
 declare -i take_prometheus_snapshot=0
 declare unique_job_prefix=
-declare snapshot_date_format='%Y_%m_%dT%H_%M_%S%z'
+# shellcheck disable=2155
+declare snapshot_date_format=$(standard_snapshot_date_format)
 declare prometheus_snapshot_start_ts=
 declare job_delay=0
 declare -i pin_jobs=1
@@ -946,7 +947,7 @@ if ((! debugonly)) ; then
 	check_runtimeclass "$runtimeclass" && runtimeclasses+=("$runtimeclass")
     done
     starting_timestamp=$(date +%s)
-    job_datestamp=$(date -u '+%Y_%m_%dT%H_%M_%S%z' --date=@"$starting_timestamp")
+    job_datestamp=$(date -u "+$(standard_snapshot_date_format)" --date=@"$starting_timestamp")
     artifactdir=${artifactdir//%s/$job_datestamp}
     if ((restart)) ; then
 	if [[ -d "$artifactdir" ]] ; then

--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -470,6 +470,7 @@ $(_document_workloads)
                                 specified, it should be either client,
                                 server, or pin.
         --no-pin-nodes          Do not pin jobs to nodes.
+        --use-pin-node=[1/0]    Pin (or not) jobs to nodes.
         --runtime=seconds       Run the job for the given number of seconds,
                                 if applicable (this does not apply to the
                                 files test).  May be overridden by
@@ -650,6 +651,11 @@ function check_clusterbuster_option() {
     [[ -n "${known_clusterbuster_options[$option]:-}" ]]
 }
 
+function artifact_dirname() {
+    local basename=${1:-cb-ci-%T}
+    echo "${basename//%T/$(printf "%($snapshot_date_format)T" -1)}"
+}
+
 function process_option() {
     local option=$1
     local noptname
@@ -667,11 +673,11 @@ function process_option() {
 	serverpin*) server_pin_node=$optvalue						;;
 	syncpin*) sync_pin_node=$optvalue						;;
 	nopinnode) pin_jobs=0								;;
-	pinnode*) pin_jobs=$(bool "$optvalue")						;;
+	usepinnode*) pin_jobs=$(bool "$optvalue")					;;
 	pin*) set_pin_node "$optvalue"							;;
 	jobruntime|runtime) job_runtime=$optvalue					;;
 	jobtimeout|timeout) job_timeout=$optvalue					;;
-	artifactdir) artifactdir="${optvalue:-${artifactdir:-$(pwd)}}"			;;
+	artifactdir) artifactdir="$(artifact_dirname "${optvalue:-}")"			;;
 	analyze*) analyze_results="$optvalue"						;;
 	reportformat*) report_format=$optvalue						;;
 	analysisformat*) analysis_format=$optvalue					;;
@@ -868,6 +874,7 @@ function run_clusterbuster_1() {
     # shellcheck disable=SC2090
     doit "$__clusterbuster__" ${dontdoit:+"$dontdoit"} --uuid="$uuid" \
 	 --precleanup --image-pull-policy=IfNotPresent \
+	 --retrieve-successful-logs=1 \
 	 --metrics --report="$report_format" --workload="$workload" \
 	 "${debugargs[@]}" \
 	 ${job_runtime:+"--workload_runtime=$job_runtime"} \
@@ -960,8 +967,8 @@ if ((! debugonly)) ; then
     fi
 
     if [[ -n "$artifactdir" && ! -d "$artifactdir" ]] ; then
-	exec > >(tee -a "$artifactdir/stdout.kata-perf-suite.log")
-	exec 2> >(tee -a "$artifactdir/stderr.kata-perf-suite.log" >&2)
+	exec > >(tee -a "$artifactdir/stdout.perf-ci-suite.log")
+	exec 2> >(tee -a "$artifactdir/stderr.perf-ci-suite.log" >&2)
     fi
 
     if ((use_python_venv)) ; then

--- a/clusterbuster
+++ b/clusterbuster
@@ -2201,6 +2201,19 @@ function _log_container() {
     fi
 }
 
+function _retrieve_vm_xml() {
+    local namespace=$1
+    local vm=$2
+    local clog="$artifactdir/VMXML/${namespace}_${vm}.xml"
+    if __OC exec -n "$namespace" "$(__OC get pod -n "$namespace" -l "vm.kubevirt.io/name=$vm" '-ojsonpath={.items[0].metadata.name}')" -- /bin/sh -c "cat '/var/run/libvirt/qemu/run/${namespace}_${vm}.xml'" > "${clog}.tmp" ; then
+	mv "${clog}.tmp" "$clog"
+	[[ -s "$clog" ]] || echo "Warning: empty qemu XML file for ${namespace}:${vm}" 1>&2
+    else
+	echo "Unable to retrieve qemu XML file for ${namespace}:${vm}" 1>&2
+	rm -f "${clog}.tmp"
+	false
+    fi
+}
 
 function _retrieve_artifacts() {
     local always_retrieve_artifacts=${1:-}
@@ -2259,7 +2272,8 @@ function _retrieve_artifacts() {
 	    wait "$job" 2>/dev/null
 	    unset "jobs_pending[$job]"
 	done
-	if [[ $runtime_class = vm ]] ; then
+	if [[ $deployment_type = vm ]] ; then
+	    [[ ! -d "$artifactdir/VMXML" ]] && mkdir "$artifactdir/VMXML"
 	    local vm
 	    local entitytype
 	    local ignore
@@ -2273,13 +2287,19 @@ function _retrieve_artifacts() {
 		    else
 			_describe_entity "$namespace" "$vm" "$entitytype"
 		    fi
+		    # Don't try to parallelize something that exec's into pods
+		    if [[ $entitytype = vm ]] ; then
+			_retrieve_vm_xml "$namespace" "$vm"
+		    fi
 		    pods_described[$name]=1
+		    if (( ${#jobs_pending[@]} > parallel_log_retrieval )) ; then
+			local -a jobs_to_wait=("${!jobs_pending[@]}")
+			for job in "${jobs_to_wait[@]}" ; do
+			    wait "$job" 2>/dev/null
+			    unset "jobs_pending[$job]"
+			done
+		    fi
 		done <<< "$(__OC get "${entitytype}" -A -l "${basename}-id=$uuid" --no-headers 2>/dev/null)"
-		local -a jobs_to_wait=("${!jobs_pending[@]}")
-		for job in "${jobs_to_wait[@]}" ; do
-		    wait "$job" 2>/dev/null
-		    unset "jobs_pending[$job]"
-		done
 	    done
 	fi
 	if [[ $deployment_type = vm && -f "$VIRTCTL" && -f "$vm_ssh_keyfile" ]] ; then
@@ -2440,15 +2460,17 @@ function get_net_interface() {
 }
 
 function get_net_interface_external() {
-    local net=$(get_net_interface "${1:-}")
-    echo ${net%%:*}
+    local net
+    net=$(get_net_interface "${1:-}")
+    echo "${net%%:*}"
 }
 
 function get_net_interface_local() {
-    local net=$(get_net_interface "${1:-}")
+    local net
+    net=$(get_net_interface "${1:-}")
     if [[ -n "$net" ]] ; then
 	if [[ $net = *":"* ]] ; then
-	    echo ${net#*:}
+	    echo "${net#*:}"
 	elif [[ ${deployment_type:-} = vm ]] ; then
 	    echo "$default_net_interface_vm"
 	else
@@ -3701,8 +3723,10 @@ EOF
 }
 
 function _increment_vm_addr() {
-    local -i a=${vm_net_addr[3]}
-    local -i b=${vm_net_addr[2]}
+    local -i a
+    a=${vm_net_addr[3]}
+    local -i b
+    b=${vm_net_addr[2]}
     a=$((a + 1))
     if ((a > 254)) ; then
 	a=1
@@ -3764,7 +3788,7 @@ function create_vm_deployment() {
     if [[ -n "$net_if" ]] ; then
 	pod_annotations+=("k8s.v1.cni.cncf.io/networks: $net_if")
     fi
-    local net_internal
+    local net_if
     net_if=$(get_net_interface_local "$node_class")
     while (( replica++ < replicas )) ; do
         local name="${depname}-${replica}"

--- a/clusterbuster
+++ b/clusterbuster
@@ -129,6 +129,9 @@ declare -i affinity=0
 declare -i sync_affinity=0
 declare -A pin_nodes=()
 declare -A runtime_classes=()
+declare -A net_interfaces=()
+declare -r default_net_interface_pod=net1
+declare -r default_net_interface_vm=eth1
 declare runtime_class=
 declare scheduler=
 declare -i verbose=0
@@ -218,8 +221,9 @@ declare -i metrics_interval=30
 declare -a sync_pod=()
 declare workload_step_interval=0
 declare -i preserve_tmpdir=0
-declare vm_ssh_keyfile=
 declare -r ssh_alg=ed25519
+declare -A __sysctls=()
+declare -i __sysctls_retrieved=0
 
 declare -r sync_flag_file="/tmp/syncfile";
 declare -r sync_error_file="/tmp/syncerror";
@@ -251,6 +255,7 @@ declare default_namespace_policy=restricted
 declare -i vm_cores=1
 declare -i vm_threads=1
 declare -i vm_sockets=1
+declare -i vm_start_running=1
 declare vm_memory=2Gi
 declare vm_grace_period=30
 declare vm_image='quay.io/rkrawitz/clusterbuster-vm:latest'
@@ -259,8 +264,9 @@ declare vm_run_as_container=0
 declare -A workload_service_ports=()
 declare vm_user=cluster
 declare vm_password=buster
-declare -A __sysctls=()
-declare -i __sysctls_retrieved=0
+declare vm_ssh_keyfile=
+# Hard code for the time being
+declare -a vm_net_addr=(192 168 129 1)
 
 declare OC=${OC:-${KUBECTL:-}}
 OC=${OC:-$(type -p oc)}
@@ -521,7 +527,7 @@ $(print_workloads_supporting_reporting '                        - ')
                           - mountopts (VMs): mount options to be used.
                           - nfsserv (VMs): NFS server for NFS-based PVCs.
                           - nfsshare (VMs): NFS share name for NFS-based
-                            PVCs.  Default to '/'.                         
+                            PVCs.  Default to '/'.
                         Notes:
                           - A previously declared mount can be overridden
                             by specifying a later mount with the same
@@ -588,6 +594,13 @@ $(print_workloads_supporting_reporting '                        - ')
                         multiple times.
        --scheduler=<scheduler>
                         Use the specified scheduler to schedule pods.
+       --interface[=:class:]=name[:internal-interface]
+                        Provide the specified network interface to the pod/VM.
+                        Class has the same meaning as for --pin-node.
+                        Internal-interface, if specified, is the name of the
+                        interface inside the pod/VM.  Normally this should not
+                        be specified, and the default (net1 for pods, eth1 for
+                        VMs) should be used.
 
     Kata Virtualization Tuning:
        --virtiofsd-writeback=[0,1]
@@ -768,6 +781,24 @@ function process_pin_node() {
     fi
 }
 
+function process_interface() {
+    local if_spec=$1
+    if_spec=${if_spec// /}
+    [[ -n "$if_spec" ]] || return
+    if [[ $if_spec = *'='* ]] ; then
+	local interface=${if_spec#*=}
+	local class=${if_spec%%=*}
+	class=${class//,/ }
+	# shellcheck disable=SC2206
+	local -a classes=($class)
+	for class in "${classes[@]}" ; do
+	    net_interfaces[$class]="$interface"
+	done
+    else
+	net_interfaces[default]="$if_spec"
+    fi
+}
+
 function process_runtimeclass() {
     local runtimespec=$1
     if [[ $runtimespec = 'vm' ]] ; then
@@ -777,8 +808,9 @@ function process_runtimeclass() {
     fi
     runtimespec=${runtimespec// /}
     runtime_class=$runtimespec
-    [[ -n "$runtimespec" ]] || return
-    if [[ $runtimespec = *'='* ]] ; then
+    if [[ -z "$runtimespec" ]] ; then
+	runtime_classes=()
+    elif [[ $runtimespec = *'='* ]] ; then
 	local runtime=${runtimespec#*=}
 	local class=${runtimespec%%=*}
 	class=${class//,/ }
@@ -810,6 +842,11 @@ function inject_error() {
     warn "*** Registering error injection '$condition' = '${injected_errors[$condition]}'"
 }
 
+function artifact_dirname() {
+    local basename=${1:-cb-%T}
+    echo "${basename//%T/$(printf "%(%Y_%m_%dT%H_%M_%S%z)T" -1)}"
+}
+
 function process_option() {
     local noptname
     local noptname1
@@ -830,7 +867,7 @@ function process_option() {
 	forceabort*)		    set -e					;;
 	preservetmpdir)		    preserve_tmpdir=$(bool "$optvalue")		;;
 	# Reporting
-	artifactdir)		    artifactdir="$optvalue"			;;
+	artifactdir)		    artifactdir="$(artifact_dirname "$optvalue")";;
 	metrics|metricsfile)	    set_metrics_file "$optvalue"		;;
 	metricsepoch)		    metrics_epoch=$optvalue			;;
 	metricsinterval)	    metrics_interval=$optvalue			;;
@@ -871,6 +908,7 @@ function process_option() {
 	processes|processesperpod)  processes_per_pod=$optvalue			;;
 	jobfile)		    process_job_file "$optvalue"		;;
 	pinnode)		    process_pin_node "$optvalue"		;;
+	interface)		    process_interface "$optvalue"		;;
 	replicas)		    replicas=$optvalue				;;
 	limit|limits)		    resource_limits+=("$optvalue")		;;
 	request|requests)	    resource_requests+=("$optvalue")		;;
@@ -1186,6 +1224,37 @@ function _____OC() {
     # as the caller.
     debug kubectl "$OC" "$@"
     exec "$OC" "$@"
+}
+
+function __VIRTCTL() {
+    if ((doit)) ; then
+	debug kubectl "$VIRTCTL" "$@"
+	"$VIRTCTL" "$@"
+    else
+	echo '(skipped)' "$VIRTCTL" "${@@Q}" 1>&2
+    fi
+}
+
+function _VIRTCTL() {
+    debug kubectl "$VIRTCTL" "$@"
+    __VIRTCTL "$@" || fatal "__KUBEFAIL__ $VIRTCTL $* failed!"
+}
+
+function ___VIRTCTL() {
+    debug kubectl "$VIRTCTL" "$@"
+    __VIRTCTL "$@" || fatal "$VIRTCTL $* failed!"
+}
+
+function ____VIRTCTL() {
+    debug kubectl "$VIRTCTL" "$@"
+    "$VIRTCTL" "$@"
+}
+
+function _____VIRTCTL() {
+    # When the oc/kubectl command must run in the same process
+    # as the caller.
+    debug kubectl "$VIRTCTL" "$@"
+    exec "$VIRTCTL" "$@"
 }
 
 function run_on_sync() {
@@ -2166,7 +2235,7 @@ function _retrieve_artifacts() {
 		else
 		    _describe_entity "$namespace" "$pod"
 		fi
-		pods_described[$name]=1
+		pods_described[$podname]=1
 	    fi
 	    if [[ -z "${containers_logged[$name]:-}" ]] ; then
 		if ((parallel_log_retrieval > 1)) ; then
@@ -2356,6 +2425,34 @@ function get_pin_node() {
 	    echo "${pin_nodes[$1]}"
 	elif [[ -n "${pin_nodes[default]:-}" ]] ; then
 	    echo "${pin_nodes[default]}"
+	fi
+    fi
+}
+
+function get_net_interface() {
+    if [[ -n "${1:-}" ]] ; then
+	if [[ -n "${net_interfaces[$1]:-}" ]] ; then
+	    echo "${net_interfaces[$1]:-}"
+	else
+	    echo "${net_interfaces[default]:-}"
+	fi
+    fi
+}
+
+function get_net_interface_external() {
+    local net=$(get_net_interface "${1:-}")
+    echo ${net%%:*}
+}
+
+function get_net_interface_local() {
+    local net=$(get_net_interface "${1:-}")
+    if [[ -n "$net" ]] ; then
+	if [[ $net = *":"* ]] ; then
+	    echo ${net#*:}
+	elif [[ ${deployment_type:-} = vm ]] ; then
+	    echo "$default_net_interface_vm"
+	else
+	    echo "$default_net_interface_pod"
 	fi
     fi
 }
@@ -3380,6 +3477,11 @@ function create_pod_deployment() {
     local -i replicas=$4
     local -i replica=0
     local depname="${namespace}-${workload}-${instance}"
+    local net_if=
+    net_if=$(get_net_interface_external "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	pod_annotations+=("k8s.v1.cni.cncf.io/networks: $net_if")
+    fi
     while (( replica++ < replicas )) ; do
 	local name="${depname}-${replica}"
 	create_object -n "$namespace" "$name" <<EOF
@@ -3569,9 +3671,71 @@ EOF
 }
 
 
+function _vm_interfaces() {
+    local net_if=
+    net_if=$(get_net_interface_external "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	cat <<EOF
+interfaces:
+  - name: default
+    masquerade: {}
+  - name: $net_if
+    bridge: {}
+EOF
+    fi
+}
+
+function _vm_networks() {
+    local net_if=
+    net_if=$(get_net_interface_external "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	cat <<EOF
+networks:
+  - name: default
+    pod: {}
+  - name: $net_if
+    multus:
+      networkName: $net_if
+EOF
+    fi
+}
+
+function _increment_vm_addr() {
+    local -i a=${vm_net_addr[3]}
+    local -i b=${vm_net_addr[2]}
+    a=$((a + 1))
+    if ((a > 254)) ; then
+	a=1
+	b=$((b + 1))
+	if ((b > 255)) ; then
+	    fatal "Out of IP addresses to assign!"
+	fi
+    fi
+    vm_net_addr[3]=$a
+    vm_net_addr[2]=$b
+}
+
+function _vm_network_data() {
+    local vm_addr=${1:-192.192.192.192}
+    local net_if=
+    net_if=$(get_net_interface_local "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	cat <<EOF
+networkData: |-
+  version: 2
+  ethernets:
+    $net_if:
+      dhcp4: false
+      dhcp6: false
+      addresses:
+        - ${vm_addr}/16
+EOF
+    fi
+}
+
 function create_vm_deployment() {
     get_sysctls
-    local node_class=client
+    local node_class=${node_class:-client}
     local namespace=$1
     local instance=$2
     local secret_count=$3
@@ -3582,6 +3746,9 @@ function create_vm_deployment() {
     local sync_ns_port_num=
     local drop_cache_service=
     local drop_cache_port_num=
+    local vm_running=true
+    local vm_addr
+    ((vm_start_running)) || vm_running=false
     pin_node=$(get_pin_node "$node_class")
     if [[ -z "$affinity_yaml" ]] ; then
 	if [[ -n "${pin_node:-}" ]] ; then
@@ -3592,12 +3759,24 @@ function create_vm_deployment() {
     fi
     local -i replica=0
     local depname="${namespace}-${workload}-${instance}"
+    local net_if=
+    net_if=$(get_net_interface_external "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	pod_annotations+=("k8s.v1.cni.cncf.io/networks: $net_if")
+    fi
+    local net_internal
+    net_if=$(get_net_interface_local "$node_class")
     while (( replica++ < replicas )) ; do
         local name="${depname}-${replica}"
         local vmname
 	vmname=$(mkpodname "$name")
 	IFS=: read -r sync_service sync_port_num sync_ns_port_num <<< "$(get_sync)"
 	IFS=: read -r drop_cache_service drop_cache_port_num <<< "$(get_drop_cache "$namespace" "$instance" "$replica")"
+	vm_addr=$(IFS=.; echo "${vm_net_addr[*]}")
+	# We can't do this as part of retrieving the VM addr because that
+	# gets read from a subshell.  Incrementing the VM address needs
+	# to be done at top level.
+	_increment_vm_addr
         create_object -t VM -n "$namespace" "$name" <<EOF
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
@@ -3606,7 +3785,7 @@ $(indent 2 standard_labels_yaml -c "$node_class" -l "$workload" "$namespace" "$i
   name: "$vmname"
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
 spec:
-  running: true
+  running: $vm_running
   template:
     metadata:
 $(indent 6 standard_labels_yaml -c "$node_class" -l "$workload" "$namespace" "$instance" "$replica")
@@ -3635,7 +3814,9 @@ $(indent 12 vm_volume_devices_yaml)
             - name: userconfigmap-${namespace}
               serial: userconfigmap
               volumeName: userconfigmap-${namespace}
+$(indent 10 _vm_interfaces)
 $(indent 8 container_resources_yaml)
+$(indent 6 _vm_networks)
       terminationGracePeriodSeconds: $vm_grace_period
 $(indent 6 <<< "$affinity_yaml")
       volumes:
@@ -3645,6 +3826,7 @@ $(indent 8 volumes_yaml -n "$namespace" "$instance" "$secret_count")
             image: $vm_image
         - name: cloudinitdisk
           cloudInitNoCloud:
+$(indent 12 _vm_network_data "$vm_addr")
             userData: |-
               #cloud-config
               ${vm_user:+user: $vm_user}
@@ -3674,6 +3856,12 @@ function create_replication_deployment() {
     local instance=$2
     local -i replicas=$4
     local name="${namespace}-${workload}-${instance}"
+    local pod_annotations=("${pod_annotations[@]}")
+    local net_if=
+    net_if=$(get_net_interface_external "$node_class")
+    if [[ -n "$net_if" ]] ; then
+	pod_annotations+=("k8s.v1.cni.cncf.io/networks: $net_if")
+    fi
     create_object -t "$deployment_type" -n "$namespace" "$name" <<EOF
 apiVersion: apps/v1
 kind: $deployment_type
@@ -4063,6 +4251,20 @@ function create_all_deployments() {
     wait "${pids[@]}" || killthemall "Unable to create deployments"
 }
 
+function create_deployments_post_hook() {
+    if [[ $deployment_type = vm && $vm_start_running -eq 0 ]] ; then
+	local namespace
+	local name
+	if [[ -z "$VIRTCTL" ]] ; then
+	    warn "*** Unable to find virtctl command, cannot start VMs!"
+	    return
+	fi
+	while read -r namespace name ; do
+	    "$VIRTCTL" start -n "$namespace" "$name"
+	done < <(__OC get vm -A -l "${basename}-xuuid=$xuuid")
+    fi
+}
+
 function create_all_objects() {
     local found_objtype
     local objtype=$1
@@ -4072,7 +4274,7 @@ function create_all_objects() {
 	if [[ $line = *'__KUBEFAIL__ '* ]] ; then
 	    echo "${line#__KUBEFAIL__ }" 1>&2
 	    return 1
-	elif [[ $line =~ ^[[:digit:]]{4}(-[[:digit:]]{2}){2}T([[:digit:]]{2}:){2}[[:digit:]]{2}\.[[:digit:]]{6}\ +(([-a-z0-9]+)(\.[-a-z0-9]*)?)/([-a-z0-9]+)\ +created$ ]] ; then
+	elif [[ $line =~ ^[[:digit:]]{4}(-[[:digit:]]{2}){2}T([[:digit:]]{2}:){2}[[:digit:]]{2}\.[[:digit:]]{6}\ +((([-a-z0-9]+)(\.[-a-z0-9]*)?)/([-a-z0-9]+))\ +created$ ]] ; then
 	    if (( report_object_creation )) ; then
 		echo "$line" 1>&2
 	    fi
@@ -4091,6 +4293,9 @@ function create_all_objects() {
 	    fi
 	fi
     done < <("create_all_${objtype}" "$@" 2>&1)
+    if [[ $(type -t "create_${objtype}_post_hook") = function ]] ; then
+	"create_${objtype}_post_hook" "${objects_created[@]}"
+    fi
 }
 
 function _do_cleanup_1() {

--- a/clusterbuster
+++ b/clusterbuster
@@ -259,12 +259,13 @@ declare -i vm_start_running=1
 declare vm_memory=2Gi
 declare vm_grace_period=30
 declare vm_image='quay.io/rkrawitz/clusterbuster-vm:latest'
-declare vm_evict_migrate=1
-declare vm_run_as_container=0
+declare -i vm_evict_migrate=1
+declare -i vm_run_as_container=0
 declare -A workload_service_ports=()
 declare vm_user=cluster
 declare vm_password=buster
 declare vm_ssh_keyfile=
+declare -i vm_run_as_root=0
 # Hard code for the time being
 declare -a vm_net_addr=(192 168 129 1)
 
@@ -643,6 +644,8 @@ $(print_workloads_supporting_reporting '                        - ')
                         VMs for log retrieval or other access purposes.
                         Default none, in which case a temporary key
                         is generated.
+       --vm-run-as-root=[0,1]
+                        Run test command as root.  Default $vm_run_as_root.
 
     Tuning object creation (short equivalents):
        --scale-ns=[0,1] Scale up the number of namespaces vs.
@@ -844,7 +847,7 @@ function inject_error() {
 
 function artifact_dirname() {
     local basename=${1:-cb-%T}
-    echo "${basename//%T/$(printf "%(%Y_%m_%dT%H_%M_%S%z)T" -1)}"
+    echo "${basename//%T/$(printf "%($(standard_snapshot_date_format))T" -1)}"
 }
 
 function process_option() {
@@ -970,6 +973,7 @@ function process_option() {
 	vmrunascontainer)	    vm_run_as_container=$(bool "$optvalue")	;;
 	vmuser)			    vm_user=$optvalue				;;
 	vmpassword)		    vm_password=$optvalue			;;
+	vmrunasroot)		    vm_run_as_root=$(bool "$optvalue")		;;
 	vmsshkey*)		    vm_ssh_keyfile=$optvalue			;;
 	# Object creation
 	obj*spercall)		    objs_per_call=$optvalue			;;
@@ -1340,9 +1344,7 @@ function stack_trace() {
 	# Line number is used as a string here, not an int,
 	# since we want the length of it as a string.
 	local line="${BASH_LINENO[$(( i - 1 ))]}"
-	if [[ $src = "$__realsc__" ]] ; then
-	    src="$__topsc__"
-	fi
+	[[ $src = "$__realsc__" ]] && src="$__topsc__"
 	((${#src} > max_filename_len)) && max_filename_len=${#src}
 	((${#line} > max_line_len)) && max_line_len=${#line}
     done
@@ -1352,9 +1354,7 @@ function stack_trace() {
 	local func="${FUNCNAME[$i]:-(top level)}"
 	local -i line="${BASH_LINENO[$(( i - 1 ))]}"
 	local src="${BASH_SOURCE[$i]:-(no file)}"
-	if [[ $src = "$__realsc__" ]] ; then
-	    src="$__topsc__"
-	fi
+	[[ $src = "$__realsc__" ]] && src="$__topsc__"
 	local -i frame_arg_count=${BASH_ARGC[$i]}
 	local argstr=
 	if ((frame_arg_count > 0)) ; then
@@ -1437,7 +1437,7 @@ function get_prometheus_pod_timestamp() {
 
 function readable_timestamp() {
     local rawtime=${1:-}
-    date -u '+%Y_%m_%dT%H_%M_%S%z' ${rawtime:+"--date=@$rawtime"}
+    date -u "+$(standard_snapshot_date_format)" ${rawtime:+"--date=@$rawtime"}
 }
 
 function set_start_timestamps() {
@@ -3105,7 +3105,7 @@ EOF
 
 function _really_create_objects() {
     if [[ $doit -ne 0 && -n $accumulateddata ]] ; then
-	__OC --validate=false apply -f - 2>&1 <<< "$accumulateddata" || {
+	__OC --validate=false create -f - 2>&1 <<< "$accumulateddata" || {
 	    echo "Create objects failed:" 1>&2
 	    echo "$accumulateddata" 1>&2
 	    set_run_aborted "Failed to create objects"
@@ -3642,6 +3642,12 @@ function _run_as_container() {
     fi
 }
 
+function _run_as_root() {
+    if ((vm_run_as_root)) ; then
+	echo -n "sudo -E "
+    fi
+}
+
 function _install_required_packages() {
     local -a packages_needed=()
     readarray -t packages_needed <<< "$(vm_required_packages)"
@@ -3867,7 +3873,7 @@ $(indent 16 _insert_ssh_keys "${vm_ssh_keyfile}.pub")
 $(indent 16 _setup_commands)
 $(indent 16 _setup_sysctls)
               runcmd:
-                - "$(standard_environment -V) $(_run_as_container)$(if [[ -n "${arglist_function}" ]] ; then
+                - "$(standard_environment -V) $(_run_as_root)  $(_run_as_container)$(if [[ -n "${arglist_function}" ]] ; then
      ARGLIST_FORMAT=vm "${arglist_function}" "${system_configmap_mount_dir}/" "$@" "0" -- \
      "$sync_nonce" "$namespace" "c0" "$basetime" "$baseoffset" "$(ts)" "$exit_at_end" "$sync_service" \
      "$sync_port_num" "$sync_ns_port_num" "$drop_cache_service" "$drop_cache_port_num" ; fi)"

--- a/lib/clusterbuster/CI/workloads/uperf.ci
+++ b/lib/clusterbuster/CI/workloads/uperf.ci
@@ -20,9 +20,6 @@ declare -ga ___uperf_ninst
 declare -ga ___uperf_test_types
 declare -gi ___uperf_job_runtime
 declare -gi ___uperf_job_timeout
-declare -g ___uperf_interface
-declare -g ___uperf_interface_server
-declare -g ___uperf_interface_client
 declare -g ___uperf_use_annotation
 
 function uperf_test() {
@@ -52,10 +49,6 @@ function uperf_test() {
 					    --uperf_test_type="$test_type" \
 					    --uperf_proto=tcp \
 					    --uperf_nthr="$nthr" \
-					    ${uperf_interface:+--uperf_interface=$___uperf_interface:} \
-					    ${uperf_interface_server:+--uperf_interface_server=$___uperf_interface_server:} \
-					    ${uperf_interface_client:+--uperf_interface_client=$___uperf_interface_client:} \
-					    --uperf_interface="$___uperf_interface" \
 					    ${___uperf_use_annotation:+--pod-annotation="io.katacontainers.config.hypervisor.default_vcpus: \"$nthr\""}
 			counter=$((counter+1))
 		    done
@@ -72,9 +65,6 @@ function uperf_initialize_options() {
     ___uperf_test_types=(stream rr)
     ___uperf_job_runtime=0
     ___uperf_job_timeout=0
-    ___uperf_interface=
-    ___uperf_interface_server=
-    ___uperf_interface_client=
     ___uperf_use_annotation=yes
 }
 
@@ -93,7 +83,6 @@ function uperf_process_option() {
 	uperftest*)    readarray -t ___uperf_test_types <<< "$(parse_optvalues "$optvalue")"	;;
 	uperf*runtime) ___uperf_job_runtime=$optvalue						;;
 	uperf*timeout) ___uperf_job_timeout=$optvalue						;;
-	uperfint*)     ___uperf_interface=$optvalue						;;
 	uperfann*)     ___uperf_use_annotation=$(bool -Y '' "$optvalue")			;;
 	*)	       return 1									;;
     esac
@@ -118,14 +107,6 @@ function uperf_help_options() {
         --uperf-timeout=seconds
                                 Time the job out after specified time.  Default
                                 is the global timeout default.
-        --uperf-interface=<interface[=pod_interface]>
-                                Specify the network interface to use.  Optional
-                                pod interface is the name of the interface on
-                                the pod (normally net1).
-        --uperf-interface-server=<interface[=pod_interface]>
-        --uperf-interface-client=<interface[=pod_interface]>
-                                Specify the interfaces for client and server
-                                separately.
         --uperf-annotate_vcpus  Provide a pod annotation for the number of
                                 vCPUs to use (default $___uperf_use_annotation)
 EOF

--- a/lib/clusterbuster/libclusterbuster.sh
+++ b/lib/clusterbuster/libclusterbuster.sh
@@ -26,6 +26,10 @@ declare -Ag debug_conditions=()
 shopt -s extdebug
 export PIDS_TO_NOT_KILL="$$ $BASHPID"
 
+function standard_snapshot_date_format() {
+    echo '%Y_%m_%dT%H_%M_%S%z'
+}
+
 function timestamp() {
     while IFS= read -r 'LINE' ; do
 	printf "%s %s\n" "$(TZ=GMT-0 date '+%Y-%m-%dT%T.%N' | cut -c1-26)" "$LINE"

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/analyze_spreadsheet_generic.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/analyze_spreadsheet_generic.py
@@ -91,11 +91,11 @@ class SpreadsheetAnalysis(ClusterBusterAnalyzeSummaryGeneric):
                         multiplier = v.get('multiplier', 1)
                         base = v.get('base', None)
                         answer += f'{name}{unit}{tab}'
-                        answer += tab.join([prettyprint(datum, multiplier=multiplier, base=base)
+                        answer += tab.join([prettyprint(datum, multiplier=multiplier, base=base, parseable=True)
                                             for datum in self._get_run_data(v_data, 'Total', metric)])
                     else:
                         answer += f'{name}'
-                        answer += '\t' + tab.join([prettyprint(datum, precision=3, base=base)
+                        answer += '\t' + tab.join([prettyprint(datum, precision=3, base=base, parseable=True)
                                                    for datum in self._get_run_data(v_data, 'Total', metric)])
                     answer += "\n"
                 answer += "\n"
@@ -122,14 +122,14 @@ Operation: {name}{unit}
 """
                 for key in self._get_all_keys(var):
                     report_answer += f'{key}{tab}'
-                    report_answer += tab.join([prettyprint(datum, multiplier=multiplier, base=base)
+                    report_answer += tab.join([prettyprint(datum, multiplier=multiplier, base=base, parseable=True)
                                                for datum in self._get_run_data(var, key, "value")]) + '\n'
                 answers.append(report_answer)
                 for op in 'ratio', 'min_ratio', 'max_ratio':
                     report_answer = f"{self._op_map[op]} {tab.join(self._runs)}" + '\n'
                     have_data = False
                     for key in self._get_all_keys(var):
-                        report_line = tab.join([prettyprint(datum, precision=3, base=base)
+                        report_line = tab.join([prettyprint(datum, precision=3, base=base, parseable=True)
                                                 for datum in self._get_run_data(var, key, op)]) + '\n'
                         if re.search(report_line, r'[0-9]'):
                             have_data = True
@@ -142,7 +142,7 @@ Operation: {name}{unit}
     def _print_safe(self, data: dict, d1, d2, d3, multiplier: float = 1):
         try:
             val = self._safe_get(data, [d1, d2, d3])
-            return prettyprint(val * multiplier, precision=3, base=0)
+            return prettyprint(val * multiplier, precision=3, base=0, parseable=True)
         except (KeyboardInterrupt, BrokenPipeError):
             sys.exit()
         except Exception:

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/files_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/files_analysis.py
@@ -22,7 +22,7 @@ class files_analysis(SpreadsheetAnalysis):
     """
 
     def __init__(self, workload: str, data: dict, metadata: dict):
-        dimensions = ['By Pod Count', 'By Dirs', 'By Files', 'By Blocksize', 'By Filesize', '-By Direct']
+        dimensions = ['By Pod Count', 'By Dirs', 'By Files', 'By Blocksize', 'By Filesize', 'By Direct']
         variables = [
             {
              'var': 'create.elapsed_time',

--- a/lib/clusterbuster/workloads/byo.workload
+++ b/lib/clusterbuster/workloads/byo.workload
@@ -78,7 +78,7 @@ function byo_process_options() {
 	    byofile*)		___byo_files+=("$optvalue")		 ;;
 	    byoname*)		___byo_name=$optvalue			 ;;
 	    byoworkdir*)	___byo_workdir=$optvalue		 ;;
-	    byodropcache)	___byo_drop_cache=$(bool $optvalue)	 ;;
+	    byodropcache)	___byo_drop_cache=$(bool "$optvalue")	 ;;
 	    *)			unknown_opts+=("$noptname ($noptname1)") ;;
 	esac
     done

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -37,8 +37,6 @@ function files_arglist() {
     local secret_count=$3
     local replicas=$4
     local containers_per_pod=$5
-    local dc_service=
-    local dc_port=0
     while [[ "$1" != '--' ]] ; do shift; done; shift
     local -i file_blocks=$((___file_size/___file_block_size))
     mk_yaml_args "python3" "${mountdir}files.py" "$@" \

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -73,7 +73,7 @@ function server_create_deployment() {
     local server_if
     server_if=$(get_net_interface server)
     for ((instance = first_deployment; instance < count + first_deployment; instance++)) ; do
-	if [[ -z "server_if" ]] ; then
+	if [[ -z "$server_if" ]] ; then
 	    create_service -k replica -e "$namespace" "${namespace}-server-server-${instance}-1" \
 			   $(seq "$___server_port" $((___server_port + ___server_port_addrs)))
 	fi

--- a/lib/clusterbuster/workloads/server.workload
+++ b/lib/clusterbuster/workloads/server.workload
@@ -19,12 +19,6 @@
 ################################################################
 
 declare -ig ___msg_size=32768
-declare -g ___server_interface=
-declare -g ___server_interface_pod=
-declare -g ___server_interface_server=
-declare -g ___server_interface_client=
-declare -g ___server_interface_pod_server=
-declare -g ___server_interface_pod_client=
 declare -gir ___server_port=30000
 declare -gi ___server_port_addrs=24
 
@@ -36,7 +30,7 @@ function server_server_arglist() {
 }
 
 function _server_sysctls() {
-    if [[ -z "$___server_interface_pod_server" ]] ; then
+    if [[ -z "$(get_net_interface server)" ]] ; then
 	cat <<EOF
 net.ipv4.ip_local_port_range $___server_port $((___server_port + ___server_port_addrs))
 EOF
@@ -48,12 +42,15 @@ function server_client_arglist() {
     local namespace=$1
     local instance=$2
     while [[ "$1" != '--' ]] ; do shift; done; shift
+    local net
+    # We need the address of the server here.
+    net=$(get_net_interface_local server)
     if [[ $target_data_rate != 0 && $target_data_rate != '' && $workload_run_time_max -eq 0 && bytes_transfer_max -eq 0 ]] ; then
 	bytes_transfer=$default_bytes_transfer
 	bytes_transfer_max=$default_bytes_transfer
     fi
     mk_yaml_args "python3" "${mountdir}client.py" "$@" \
-		 "${___server_interface_pod:+${___server_interface_pod}@}${namespace}-server-server-${instance}-1" \
+		 "${net:+${net}@}${namespace}-server-server-${instance}-1" \
 		 "$___server_port" "$target_data_rate" "$bytes_transfer" \
 		 "$bytes_transfer_max" "$___msg_size" "$workload_run_time" "$workload_run_time_max"
 }
@@ -66,32 +63,6 @@ function server_create_deployment() {
     local containers_per_pod=${5:-1}
     local replicas_per_server=$replicas
     local -i instance
-    local server_annotation
-    local client_annotation
-    if [[ -n "$___server_interface" ]] ; then
-	___server_interface_server=${___server_interface_server:-$___server_interface}
-	___server_interface_client=${___server_interface_client:-$___server_interface}
-    fi
-    if [[ -n "$___server_interface_client" ]] ; then
-	if [[ $___server_interface_client = *'='* ]] ; then
-	    ___server_interface_pod_client=${___server_interface_client#*=}
-	    ___server_interface_client=${___server_interface_client%%=*}
-	fi
-	if [[ -z "$___server_interface_pod_client" && $___server_interface_client != eth0 ]] ; then
-	    ___server_interface_pod_client=net1
-	fi
-	client_annotation="k8s.v1.cni.cncf.io/networks: $___server_interface_client"
-    fi
-    if [[ -n "$___server_interface_server" ]] ; then
-	if [[ $___server_interface_server = *'='* ]] ; then
-	    ___server_interface_pod_server=${___server_interface_server#*=}
-	    ___server_interface_server=${___server_interface_server%%=*}
-	fi
-	if [[ -z "$___server_interface_pod_server" && $___server_interface_server != eth0 ]] ; then
-	    ___server_interface_pod_server=net1
-	fi
-	server_annotation="k8s.v1.cni.cncf.io/networks: $___server_interface_server"
-    fi
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___server_port_addrs)) ; then
 	___server_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
@@ -99,8 +70,10 @@ function server_create_deployment() {
 			"$((containers_per_pod * replicas * count))" \
 			"$(((containers_per_pod * replicas * count)+count))"
 
+    local server_if
+    server_if=$(get_net_interface server)
     for ((instance = first_deployment; instance < count + first_deployment; instance++)) ; do
-	if [[ -z "${___server_interface}" ]] ; then
+	if [[ -z "server_if" ]] ; then
 	    create_service -k replica -e "$namespace" "${namespace}-server-server-${instance}-1" \
 			   $(seq "$___server_port" $((___server_port + ___server_port_addrs)))
 	fi
@@ -109,7 +82,7 @@ function server_create_deployment() {
 				   -a server_server_arglist \
 				   ${server_annotation:+-N "$server_annotation"} \
 				   "$namespace" "$instance" "$secret_count" 1 1
-	create_standard_deployment -w server-client \
+	create_standard_deployment -w server-client -c client \
 				   -A "$(create_affinity_yaml "${namespace}-server-server-${instance}")" \
 				   -a server_client_arglist \
 				   ${client_annotation:+-N "$client_annotation"} \
@@ -127,19 +100,11 @@ EOF
 function server_help_options() {
     cat <<'EOF'
     Client/server Options:
-       --server-interface=<interface[=pod_interface]>
-                       Specify the network interface to use.  Optional
-                       pod interface is the name of the interface on the
-                       pod (normally net1).
        --msgsize       Message size in data transfer
        --pin_node=server=<node>
                        Specify node to which the server is bound.
        --pin_node=client=<node>
                        Specify node to which the client is bound.
-       --server-interface-server=<interface[=pod_interface]>
-       --server-interface-client=<interface[=pod_interface]>
-                       Specify the interfaces for client and server
-                       separately.
 EOF
 }
 
@@ -158,9 +123,6 @@ function server_process_options() {
 	read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
 	case "$noptname1" in
 	    msgsize) ___msg_size=$optvalue			    ;;
-	    serverinterface) ___server_interface=$optvalue	    ;;
-	    serverinterfaces*) ___server_interface_server=$optvalue ;;
-	    serverinterfacec*) ___server_interface_client=$optvalue ;;
 	    *) unknown_opts+=("$noptname ($noptname1)")		    ;;
 	esac
     done
@@ -174,10 +136,7 @@ function server_process_options() {
 
 function server_report_options() {
     cat <<EOF
-"msg_size": $___msg_size,
-"interface": "${___server_interface}",
-"server_interface": "${___server_interface_server}",
-"client_interface": "${___server_interface_client}"
+"msg_size": $___msg_size
 EOF
 }
 

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -26,11 +26,6 @@ declare -ag ___uperf_tests=()
 declare -gir ___uperf_port=30000
 declare -gi ___uperf_port_addrs=24
 declare -gi ___uperf_ramp_time=3
-declare -g ___uperf_interface=
-declare -g ___uperf_interface_server=
-declare -g ___uperf_interface_client=
-declare -g ___uperf_interface_pod_server=
-declare -g ___uperf_interface_pod_client=
 
 function uperf_server_arglist() {
     local mountdir=$1; shift
@@ -39,7 +34,7 @@ function uperf_server_arglist() {
 }
 
 function uperf_sysctls() {
-    if [[ -z "$___uperf_interface_pod_server" ]] ; then
+    if [[ -z "$(get_net_interface server)" ]] ; then
 	cat <<EOF
 net.ipv4.ip_local_port_range $___uperf_port $((___uperf_port + ___uperf_port_addrs))
 EOF
@@ -48,10 +43,14 @@ EOF
 
 function uperf_client_arglist() {
     local mountdir=$1; shift
+    local namespace=$1
+    local instance=$2
     while [[ "$1" != '--' ]] ; do shift; done; shift
+    local net
     # We need the address of the server, hence using $uperf_interface_pod_server
+    net=$(get_net_interface_local server)
     mk_yaml_args "python3" "${mountdir}uperf-client.py" "$@" "$workload_run_time" "$___uperf_ramp_time" \
-		 "${___uperf_interface_pod_server:+${___uperf_interface_pod_server}@}${namespace}-uperf-server-${instance}-1" \
+		 "${net:+${net}@}${namespace}-uperf-server-${instance}-1" \
 		 "$___uperf_port" "${___uperf_tests[@]}"
 }
 
@@ -62,32 +61,6 @@ function uperf_create_deployment() {
     local replicas=${4:-1}
     local containers_per_pod=${5:-1}
     local -i instance
-    local server_annotation
-    local client_annotation
-    if [[ -n "$___uperf_interface" ]] ; then
-	___uperf_interface_server=${___uperf_interface_server:-$___uperf_interface}
-	___uperf_interface_client=${___uperf_interface_client:-$___uperf_interface}
-    fi
-    if [[ -n "$___uperf_interface_client" ]] ; then
-	if [[ $___uperf_interface_client = *'='* ]] ; then
-	    ___uperf_interface_pod_client=${___uperf_interface_client#*=}
-	    ___uperf_interface_client=${___uperf_interface_client%%=*}
-	fi
-	if [[ -z "$___uperf_interface_pod_client" && $___uperf_interface_client != eth0 ]] ; then
-	    ___uperf_interface_pod_client=net1
-	fi
-	client_annotation="k8s.v1.cni.cncf.io/networks: $___uperf_interface_client"
-    fi
-    if [[ -n "$___uperf_interface_server" ]] ; then
-	if [[ $___uperf_interface_server = *'='* ]] ; then
-	    ___uperf_interface_pod_server=${___uperf_interface_server#*=}
-	    ___uperf_interface_server=${___uperf_interface_server%%=*}
-	fi
-	if [[ -z "$___uperf_interface_pod_server" && $___uperf_interface_server != eth0 ]] ; then
-	    ___uperf_interface_pod_server=net1
-	fi
-	server_annotation="k8s.v1.cni.cncf.io/networks: $___uperf_interface_server"
-    fi
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
@@ -96,8 +69,10 @@ function uperf_create_deployment() {
 			"$((containers_per_pod * replicas * count))" \
 			"$(( (containers_per_pod * replicas * count) + count))"
 
+    local server_if
+    server_if=$(get_net_interface server)
     for ((instance = first_deployment; instance < count + first_deployment; instance++)) ; do
-	if [[ -z "${___uperf_interface}" ]] ; then
+	if [[ -z "$server_if" ]] ; then
 	    create_service -k replica -e "$namespace" "${namespace}-uperf-server-${instance}-1" \
 			   $(seq "$___uperf_port" $((___uperf_port + ___uperf_port_addrs)))
 	fi
@@ -106,7 +81,7 @@ function uperf_create_deployment() {
 				   -a uperf_server_arglist \
 				   ${server_annotation:+-N "$server_annotation"} \
 				   "$namespace" "$instance" "$secret_count" 1 1
-	create_standard_deployment -w uperf-client \
+	create_standard_deployment -w uperf-client -c client \
 				   -A "$(create_affinity_yaml "${namespace}-uperf-server-${instance}")" \
 				   -a uperf_client_arglist \
 				   ${client_annotation:+-N "$client_annotation"} \
@@ -133,15 +108,7 @@ function uperf_help_options() {
                        Specify node to which the client is bound.
        --uperf-ramp-time=<sec>
                        Specify the ramp time for uperf.
-       --uperf-interface=<interface[=pod_interface]>
-                       Specify the network interface to use.  Optional
-                       pod interface is the name of the interface on the
-                       pod (normally net1).
-       --uperf-interface-server=<interface[=pod_interface]>
-       --uperf-interface-client=<interface[=pod_interface]>
-                       Specify the interfaces for client and server
-                       separately.
-     The following options take a comma-separated list of each
+     the following options take a comma-separated list of each
      value to test.  The outer product of all specified tests
      is run.
        --uperf-msg-size=<sizes>
@@ -175,9 +142,6 @@ function uperf_process_options() {
 	    uperfproto*) ___uperf_protos=(${optvalue//,/ })	   ;;
 	    uperfnthr*) ___uperf_nthrs=(${optvalue//,/ })	   ;;
 	    uperframp*) ___uperf_ramp_time=$optvalue		   ;;
-	    uperfinterface) ___uperf_interface=$optvalue	   ;;
-	    uperfinterfaces*) ___uperf_interface_server=$optvalue  ;;
-	    uperfinterfacec*) ___uperf_interface_client=$optvalue  ;;
 	    *) unknown_opts+=("$noptname ($noptname1)")		   ;;
 	esac
     done
@@ -263,9 +227,7 @@ function uperf_report_options() {
 "test_types": $(__uperf_stringify -s "${___uperf_test_types[@]}"),
 "protocols": $(__uperf_stringify -s "${___uperf_protos[@]}"),
 "nthrs": $(__uperf_stringify -n "${___uperf_nthrs[@]}"),
-"ramp_time": ${___uperf_ramp_time},
-"server_interface": "${___uperf_interface_server}",
-"client_interface": "${___uperf_interface_client}"
+"ramp_time": ${___uperf_ramp_time}
 EOF
 }
 


### PR DESCRIPTION
- Retrieve qemu XML files from VMs
- Support multiple networks for VMs with multus (we have to do our own address assignment as CNV doesn't work with IPAM)
- Generate artifact directory names from timestamp to avoid inadvertently overwriting existing artifact directories.
- Retrieve all logs, not just from failing pods, in CI.
- Rename the stdout/stderr CI logs to reflect the change from kata to perf CI.
- Move the network interface options from uperf and server to top level to aid code reuse and simplify the logic.
- Change the reply from the sync to the workers to JSON so we can add more data to it if we need to.
- Ensure that all spreadsheet analysis is printed in numbers rather than suffixed human friendly.
- Files analysis should also analyze by direct vs. std IO.