### PR TITLE
Miscellaneous improvements/fixes:

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -610,33 +610,33 @@ function test_parse() {
 	fi
     }
 
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files pod
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files kata
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files pod
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files kata
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio pod
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio kata
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio pod
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio kata
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker vm
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker pod
-    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker kata
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker vm
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker pod
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto cpusoaker kata
-    _test_parse volume:files:!pod,!kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto
-    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files
-    _test_parse volume:files:vm,kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files:pod,kata=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files:!vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto files vm
-    _test_parse volume:files:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio
-    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/tmp/clusterbuster:size=auto:inodes=auto fio vm
-    _test_parse volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster:size=auto fio
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files kata
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio kata
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker vm
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker pod
+    _test_parse volume:files,fio:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker kata
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker vm
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker pod
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto cpusoaker kata
+    _test_parse volume:files:!pod,!kata=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto
+    _test_parse volume:files:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files
+    _test_parse volume:files:vm,kata=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:pod,kata=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:!vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto files vm
+    _test_parse volume:files:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio
+    _test_parse volume:files,fio:vm=test-pvc:pvc:/var/opt/clusterbuster:size=auto:inodes=auto fio vm
+    _test_parse volume:files,fio:!vm=:emptydir:/var/opt/clusterbuster:size=auto fio
 }
 
 function check_clusterbuster_option() {
@@ -730,10 +730,10 @@ fi
 
 while getopts 'hn-:B:' opt ; do
     case "$opt" in
-	-) process_option "$OPTARG"	;;
-	h) help				;;
-	n) debugonly=1; dontdoit=-n	;;
-	*)				;;
+	-) process_option "$OPTARG"			;;
+	h) help						;;
+	n) debugonly=$((debugonly+1)); dontdoit=-n	;;
+	*)						;;
     esac
 done
 
@@ -793,14 +793,18 @@ function to_hms() {
 
 function doit() {
     echo "${@@Q}"
-    if ((! debugonly)) ; then
-	exec "$@" &
-	job_pid=$!
-	wait "$job_pid"
-	local status=$?
-	job_pid=
-	return $status
-    fi
+    case "$debugonly" in
+	0|'')
+	    exec "$@" &
+	    job_pid=$!
+	    wait "$job_pid"
+	    local status=$?
+	    job_pid=
+	    return $status
+	    ;;
+	1) ;;
+	*) "$@" ;;
+    esac
 }
 
 function check_runtimeclass() {

--- a/analyze-clusterbuster-report
+++ b/analyze-clusterbuster-report
@@ -69,7 +69,10 @@ def analyze_clusterbuster(f):
         dir_args = args.files
     if args.workload:
         dir_args = [f'{f}:job_pattern=^({"|".join(args.workload)})-' for f in dir_args]
-    analyze_clusterbuster_1(f, ClusterBusterLoader(extras).loadFromSpecs(dir_args), extras)
+    try:
+        analyze_clusterbuster_1(f, ClusterBusterLoader(extras).loadFromSpecs(dir_args), extras)
+    except ClusterBusterReportingException as exc:
+        print(f"Report failed: {exc}")
 
 
 try:

--- a/clusterbuster
+++ b/clusterbuster
@@ -163,7 +163,7 @@ declare -i scale_deployments=1
 declare -i sync_start=1
 declare -a volumes=()
 declare -A mount_volume_map=()
-declare common_workdir=/var/tmp/clusterbuster
+declare common_workdir=/var/opt/clusterbuster
 declare -i report=0
 declare report_format=summary
 declare -i precleanup=1
@@ -377,7 +377,7 @@ Extended Options:
                         starts before it starts running.
        --postdelay=N    Delay for the specified time after workload
                         completes.
-       --stepinterval=N	Delay the specified time between steps of the workload.
+       --stepinterval=N Delay the specified time between steps of the workload.
        --timeout=N      Time out reporting after N seconds
        --report_object_creation=<1,0>
                         Report creation of individual objects (default 1)
@@ -536,9 +536,9 @@ $(print_workloads_supporting_reporting '                        - ')
                           - A previously declared mount can be removed by
                             specifying a mount with the same mountpoint
                             and empty name and type.  Example:
-                            --volume=:emptydir:/var/tmp/clusterbuster
-                            --volume=::/var/tmp/clusterbuster
-                            will result in no mount on /var/tmp/clusterbuster
+                            --volume=:emptydir:/var/opt/clusterbuster
+                            --volume=::/var/opt/clusterbuster
+                            will result in no mount on /var/opt/clusterbuster
                             unless later overridden.
                           - All previously declared mounts can be removed
                             by specifying a mount with no name, type,
@@ -551,8 +551,13 @@ $(print_workloads_supporting_reporting '                        - ')
        --container_image=<image>
                         Image to use (default $container_image).
                         Does not apply to "classic" or "pause" workloads.
-       --deployment_type=<pod,deployment,vm>
-                        Deploy via individual pods, deployments or vm (default $deployment_type)
+       --deployment_type=<pod,deployment,replicaset,vm>
+                        Deploy via individual pods, deployments, replica sets,
+                        or vms (default $deployment_type).
+                        Note that functionality that relies on fixed pod
+                        names or recognition of distinct pods (e. g.
+                        the %i functionality in volumes) will not work
+                        correctly with deployments or replicasets.
        --external_sync=host:port
                         Sync to external host rather than internally
        --request=<resource=value>
@@ -720,12 +725,12 @@ EOF
 }
 
 function help() {
-    _help_extended | "${PAGER:-more}"
+    _help_extended "$@" | "${PAGER:-more}"
     exit 1
 }
 
 function help_extended() {
-    _help_extended | "${PAGER:-more}"
+    _help_extended "$@" | "${PAGER:-more}"
     exit 1
 }
 
@@ -2806,6 +2811,17 @@ EOF
     fi
 }
 
+function expand_volume() {
+    local scoped_name=$1
+    local namespace=${2:+$2}
+    local instance=${3:+$3}
+    local replica=${4:+$4}
+    scoped_name=${scoped_name//%N/$namespace}
+    scoped_name=${scoped_name//%i/$instance}
+    scoped_name=${scoped_name//%r/$replica}
+    echo "$scoped_name"
+}
+
 function volume_mounts_yaml() {
     local OPTIND=0
     local use_extra_volumes=1
@@ -2817,13 +2833,13 @@ function volume_mounts_yaml() {
     done
     shift $((OPTIND-1))
     local namespace=$1
-    local deployment=${2:-1}
+    local instance=${2:-1}
     local secrets=${3:-1}
     (( secrets + ${#configmap_files[@]} + ${#volumes[@]} + has_system_configmap + has_user_configmap )) || return;
     local -i i
     echo volumeMounts:
     for ((i = 0; i < secrets; i++)) ; do
-	local name="secret-${namespace}-${deployment}-$i"
+	local name="secret-${namespace}-${instance}-$i"
 	cat <<EOF
 - name: $name
   mountPath: /etc/$name
@@ -2853,6 +2869,7 @@ EOF
 	    local name=${args[0]}
 	    local type=${args[1]}
 	    local mountpoint=${args[2]}
+	    name=$(expand_volume "$name" "$namespace" "$instance" "$replica")
 
 	    args=("${args[@]:3}")
 	    case "${type,,}" in
@@ -2936,17 +2953,6 @@ function standard_pod_metadata_yaml() {
     annotations_yaml "$class"
 }
 
-function expand_volume() {
-    local scoped_name=$1
-    local namespace=${2:+$2}
-    local instance=${3:+$3}
-    local replica=${4:+$4}
-    scoped_name=${scoped_name//%N/$namespace}
-    scoped_name=${scoped_name//%i/$instance}
-    scoped_name=${scoped_name//%r/$replica}
-    echo "$scoped_name"
-}
-
 function extra_volumes_yaml() {
     local volspec
     local -i emptyvolid=0
@@ -2974,7 +2980,7 @@ function extra_volumes_yaml() {
 		done
 		claim_name=$(expand_volume "$claim_name" "$namespace" "$instance" "$replica")
 		cat <<EOF
-- name: $name
+- name: $claim_name
   persistentVolumeClaim:
     claimName: $claim_name
 ${size:+    capacity: "$size"}
@@ -3532,6 +3538,7 @@ function vm_volume_devices_yaml() {
 	local name=${args[0]}
 	local type=${args[1]}
 	local mountpoint=${args[2]}
+	name=$(expand_volume "$name" "$namespace" "$instance" "$replica")
 	[[ ${type,,} = emptydir ]] && continue
 	args=("${args[@]:3}")
 	local opt
@@ -3600,6 +3607,7 @@ function vm_volume_mounts_yaml() {
 	    command="mkdir -p '$mountpoint' && mount $mountopts '$remote' '$mountpoint' && chmod 777 '$mountpoint'"
 	else
 	    [[ "${type,,}" = emptydisk ]] && name="cbemptydisk$((emptydiskid++))"
+	    name=$(expand_volume "$name" "$namespace" "$instance" "$replica")
 	    name="${bus}-${name}"
 	    if [[ -n "$fstype" ]] ; then
 		local sinodes=
@@ -3763,6 +3771,18 @@ EOF
     fi
 }
 
+function _vm_container_disk_yaml() {
+    if [[ -n "${vm_image:-}" ]] ; then
+	cat <<EOF
+- name: containerdisk
+  disk:
+    bus: virtio
+  containerDisk:
+    image: $vm_image
+EOF
+    fi
+}
+
 function create_vm_deployment() {
     get_sysctls
     local node_class=${node_class:-client}
@@ -3834,9 +3854,7 @@ $(indent 6 _vm_evict_strategy)
           guest: $vm_memory
         devices:
           disks:
-            - name: containerdisk
-              disk:
-                bus: virtio
+$(indent 12 _vm_container_disk_yaml)
 $(indent 12 vm_volume_devices_yaml)
             - name: systemconfigmap-${namespace}
               serial: systemconfigmap
@@ -3864,7 +3882,7 @@ $(indent 12 _vm_network_data "$vm_addr")
               ${vm_password:+password: $vm_password}
               chpasswd: { expire: False }
               bootcmd:
-                - "mkdir '$system_configmap_mount_dir' '$user_configmap_mount_dir'"
+                - "mkdir -p '$system_configmap_mount_dir' '$user_configmap_mount_dir'"
 $(indent 16 vm_volume_mounts_yaml)
                 - "mount -o ro /dev/disk/by-id/ata-QEMU_HARDDISK_systemconfigmap '$system_configmap_mount_dir'"
                 - "mount -o ro /dev/disk/by-id/ata-QEMU_HARDDISK_userconfigmap '$user_configmap_mount_dir'"
@@ -4223,11 +4241,19 @@ function create_all_secrets() {
 function create_system_configmap() {
     local -a systemfiles
     readarray -t systemfiles < <(list_configmaps | grep .)
+    if [[ -n "$artifactdir" && -n "${systemfiles[*]}" ]] ; then
+	mkdir -p "$artifactdir/SYSFILES" || fatal "Can't create system artifacts directory"
+	cp -p "${systemfiles[@]}" "$artifactdir/SYSFILES"
+    fi
     if [[ ${#systemfiles[@]} -gt 0 && $sync_start -ne 0 && -n "$sync_namespace" && $sync_in_first_namespace -eq 0 ]] ; then
 	create_configmaps "$sync_namespace" "systemconfigmap" "${systemfiles[@]}"
     fi
     local -a userfiles
     readarray -t userfiles < <(list_user_configmaps | grep .)
+    if [[ -n "$artifactdir" && -n "${userfiles[*]}" ]] ; then
+	mkdir -p "$artifactdir/USERFILES" || fatal "Can't create user artifacts directory"
+	cp -p "${userfiles[@]}" "$artifactdir/USERFILES"
+    fi
     for ((i = 0; i < parallel_configmaps; i++)) ; do
 	create_objects_n configmaps "$parallel_configmaps" "$objs_per_call_configmaps" "$i" "$sleep_between_configmaps" "systemconfigmap" "${systemfiles[@]}"&
 	pids+=("$!")
@@ -4602,6 +4628,8 @@ function run_clusterbuster_2() {
 	    # causing upstream broken pipes and loss of error data.
 	    exec 2> >(trap '' TERM INT HUP USR1 USR2; stdbuf -i0 -o0 -e0 tee >(trap '' TERM INT HUP USR1 USR2; stdbuf -i0 -o0 -e0 tr "\r" "\n" > "$artifactdir/stderr.log") >&2)
 	fi
+    else
+	artifactdir=
     fi
     setup_namespaces || return 1
     create_all_objects namespaces || return 1
@@ -4890,7 +4918,7 @@ while getopts ":B:Eef:Hhno:P:w:QqvN-:" opt ; do
 	v) process_option "verbose=1"		 ;;
 	w) process_option "workload=$OPTARG"     ;;
 	-) process_option "$OPTARG"		 ;;
-	*) help "$OPTARG"			 ;;
+	*) help "Unknown option -$OPTARG"	 ;;
     esac
 done
 

--- a/lib/clusterbuster/CI/profiles/func_ci.profile
+++ b/lib/clusterbuster/CI/profiles/func_ci.profile
@@ -34,6 +34,6 @@ cleanup=1
 restart=0
 deployment-type=replicaset
 
-volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
-volume:files:vm=:emptydisk:/var/tmp/clusterbuster:size=auto:inodes=auto
-volume:fio:vm=:emptydisk:/var/tmp/clusterbuster:size=auto
+volume:files,fio:!vm=:emptydir:/var/opt/clusterbuster
+volume:files:vm=:emptydisk:/var/opt/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=:emptydisk:/var/opt/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/perf_ci.profile
+++ b/lib/clusterbuster/CI/profiles/perf_ci.profile
@@ -35,6 +35,6 @@ cleanup=1
 restart=0
 deployment-type=replicaset
 
-volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
-volume:files:vm=:emptydisk:/var/tmp/clusterbuster:size=auto:inodes=auto
-volume:fio:vm=:emptydisk:/var/tmp/clusterbuster:size=auto
+volume:files,fio:!vm=:emptydir:/var/opt/clusterbuster
+volume:files:vm=:emptydisk:/var/opt/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=:emptydisk:/var/opt/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/release.profile
+++ b/lib/clusterbuster/CI/profiles/release.profile
@@ -39,6 +39,6 @@ use-python-venv=1
 cleanup=1
 deployment-type=replicaset
 
-volume:files,fio:!vm=:emptydir:/var/tmp/clusterbuster
-volume:files:vm=:emptydisk:/var/tmp/clusterbuster:size=auto:inodes=auto
-volume:fio:vm=:emptydisk:/var/tmp/clusterbuster:size=auto
+volume:files,fio:!vm=:emptydir:/var/opt/clusterbuster
+volume:files:vm=:emptydisk:/var/opt/clusterbuster:size=auto:inodes=auto
+volume:fio:vm=:emptydisk:/var/opt/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/profiles/test_ci.profile
+++ b/lib/clusterbuster/CI/profiles/test_ci.profile
@@ -35,6 +35,6 @@ cleanup=1
 restart=0
 deployment-type=replicaset
 
-volume:files,fio:pod,kata=:emptydir:/var/tmp/clusterbuster
-volume:files:vm=:emptydisk:/var/tmp/clusterbuster:fstype=ext4:size=auto:inodes=auto
-volume:fio:vm=:emptydisk:/var/tmp/clusterbuster:size=auto
+volume:files,fio:pod,kata=:emptydir:/var/opt/clusterbuster
+volume:files:vm=:emptydisk:/var/opt/clusterbuster:fstype=ext4:size=auto:inodes=auto
+volume:fio:vm=:emptydisk:/var/opt/clusterbuster:size=auto

--- a/lib/clusterbuster/CI/workloads/fio.ci
+++ b/lib/clusterbuster/CI/workloads/fio.ci
@@ -136,7 +136,7 @@ function fio_initialize_options() {
     ___fio_ioengines=(sync libaio)
     ___fio_ninst=(1 4)
     ___fio_job_runtime=0
-    ___fio_workdir=/var/tmp/clusterbuster
+    ___fio_workdir=/var/opt/clusterbuster
     ___fio_absolute_filesize=0
     ___fio_max_absolute_filesize=0
     ___fio_relative_filesize=2

--- a/lib/clusterbuster/pod_files/files.py
+++ b/lib/clusterbuster/pod_files/files.py
@@ -20,7 +20,7 @@ class files_client(clusterbuster_pod_client):
             if len(self._args) > 6:
                 self.dir_list = self._args[6:]
             else:
-                self.dir_list = ['/var/tmp/clusterbuster']
+                self.dir_list = ['/var/opt/clusterbuster']
             self.dirs = self._toSize(self._args[0])
             self.files_per_dir = self._toSize(self._args[1])
             self.blocksize = self._toSize(self._args[2])
@@ -165,6 +165,8 @@ class files_client(clusterbuster_pod_client):
         return answer
 
     def runit(self, process: int):
+        for tree in self.dir_list:
+            self._cleanup_tree(tree)
         self.localid = self._idname(separator='-')
         self.removethem(process, True)
         data_start_time = self._adjusted_time()

--- a/lib/clusterbuster/pod_files/fio.py
+++ b/lib/clusterbuster/pod_files/fio.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import re
 import json
-import shutil
 import tempfile
 
 from clusterbuster_pod_client import clusterbuster_pod_client
@@ -48,6 +47,9 @@ class fio_client(clusterbuster_pod_client):
             return None
 
     def prepare_data_file(self, jobfile: str):
+        self._timestamp("Jobfile:")
+        with open(jobfile) as job:
+            self._timestamp(job.read())
         with open(jobfile) as job:
             lines = [line.strip() for line in job.readlines()]
             for line in lines:
@@ -164,6 +166,7 @@ Drop cache:  {self.fio_drop_cache}""")
         except Exception:
             odir = '/'
         try:
+            self._cleanup_tree(self.rundir, process == 0)
             localid = self._idname(separator='-')
             localrundir = os.path.join(self.rundir, localid)
             tmp_jobsfiledir = os.path.join(self.rundir, f'fio-{localid}.job')
@@ -187,8 +190,7 @@ Drop cache:  {self.fio_drop_cache}""")
                 self.runone(jobfile)
         finally:
             os.chdir(odir)
-            for dir in dirs_to_remove:
-                shutil.rmtree(dir, ignore_errors=True)
+            self._cleanup_tree(self.rundir, process == 0)
 
 
 fio_client().run_workload()

--- a/lib/clusterbuster/reporting/analysis/ci/analyze_ci_generic.py
+++ b/lib/clusterbuster/reporting/analysis/ci/analyze_ci_generic.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOne
+from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOneBase
 
 
-class CIAnalysis(ClusterBusterAnalyzeOne):
+class CIAnalysis(ClusterBusterAnalyzeOneBase):
     """
     Analyze files data
     """

--- a/lib/clusterbuster/reporting/analysis/ci/analyze_postprocess.py
+++ b/lib/clusterbuster/reporting/analysis/ci/analyze_postprocess.py
@@ -17,7 +17,7 @@ from ..ClusterBusterAnalysis import ClusterBusterAnalysisException, ClusterBuste
 import argparse
 
 
-class ClusterBusterAnalysisJobMismatchException(ClusterBusterAnalysisException):
+class _ClusterBusterAnalysisJobMismatchException(ClusterBusterAnalysisException):
     def __init__(self, var: str, job: str, val1, val2):
         super().__init__(f"Mismatched {var} in {job}: ({val1} vs {val2})")
 
@@ -38,8 +38,8 @@ class AnalyzePostprocess(ClusterBusterPostprocessBase):
             if self._report['metadata'][var] is None:
                 self._report['metadata'][var] = you.get(var, None)
             elif you.get(var, None) is not None and you[var] != self._report['metadata'][var]:
-                raise ClusterBusterAnalysisJobMismatchException(var, job, you[var],
-                                                                self._report['metadata'][var])
+                raise _ClusterBusterAnalysisJobMismatchException(var, job, you[var],
+                                                                 self._report['metadata'][var])
 
     def Postprocess(self):
         self._report['metadata'] = {

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/cpusoaker_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/cpusoaker_analysis.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOne
+from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOneBase
 from ...prettyprint import prettyprint
 
 
-class cpusoaker_analysis(ClusterBusterAnalyzeOne):
+class cpusoaker_analysis(ClusterBusterAnalyzeOneBase):
     """
     Analyze cpusoaker data
     """

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/fio_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/fio_analysis.py
@@ -22,7 +22,7 @@ class fio_analysis(SpreadsheetAnalysis):
     """
 
     def __init__(self, workload: str, data: dict, metadata: dict):
-        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', '-By Fdatasync', '-By Direct', 'By Operation', 'By Blocksize']
+        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', '-By Fdatasync', 'By Direct', 'By Operation', 'By Blocksize']
         variables = [
             {
              'var': 'throughput',
@@ -35,6 +35,18 @@ class fio_analysis(SpreadsheetAnalysis):
              'name': 'IO/sec',
              'base': 0,
              'detail': False
+             },
+            {
+             'var': 'latency_avg',
+             'name': 'Avg latency (msec)',
+             'base': 0,
+             'multiplier': .000001
+             },
+            {
+             'var': 'latency_max',
+             'name': 'Max latency (msec)',
+             'base': 0,
+             'multiplier': .000001
              }
              ]
         filters = {

--- a/lib/clusterbuster/reporting/analysis/summary/analyze_generic.py
+++ b/lib/clusterbuster/reporting/analysis/summary/analyze_generic.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOne
+from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOneBase
 from math import log, exp
 
 
-class ClusterBusterAnalyzeSummaryGeneric(ClusterBusterAnalyzeOne):
+class ClusterBusterAnalyzeSummaryGeneric(ClusterBusterAnalyzeOneBase):
     """
     Analyze data from multi-dimensional workloads
     """

--- a/lib/clusterbuster/reporting/analysis/summary/cpusoaker_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/summary/cpusoaker_analysis.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOne
+from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOneBase
 
 
-class cpusoaker_analysis(ClusterBusterAnalyzeOne):
+class cpusoaker_analysis(ClusterBusterAnalyzeOneBase):
     """
     Analyze cpusoaker data
     """

--- a/lib/clusterbuster/reporting/analysis/summary/files_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/summary/files_analysis.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOne
+from ..ClusterBusterAnalysis import ClusterBusterAnalyzeOneBase
 from math import log, exp
 
 
-class FilesAnalysisBase(ClusterBusterAnalyzeOne):
+class FilesAnalysisBase(ClusterBusterAnalyzeOneBase):
     """
     Analyze files data
     """

--- a/lib/clusterbuster/reporting/analysis/summary/fio_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/summary/fio_analysis.py
@@ -23,7 +23,7 @@ class fio_analysis(ClusterBusterAnalyzeSummaryGeneric):
 
     def __init__(self, workload: str, data: dict, metadata: dict):
         dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', '-By Fdatasync', '-By Direct', 'By Operation', 'By Blocksize']
-        variables = ['throughput', 'iops']
+        variables = ['throughput', 'iops', 'latency_avg', 'latency_max']
         filters = {
             'By Direct': self.__filter_direct
             }

--- a/lib/clusterbuster/reporting/loader/cpusoaker_loader.py
+++ b/lib/clusterbuster/reporting/loader/cpusoaker_loader.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .ClusterBusterLoader import LoadOneReport
+from .ClusterBusterLoader import ClusterBusterLoadOneReportBase
 
 
-class cpusoaker_loader(LoadOneReport):
+class cpusoaker_loader(ClusterBusterLoadOneReportBase):
     def __init__(self, name: str, report: dict, data: dict, extras=None):
         super().__init__(name, report, data, extras=extras)
 

--- a/lib/clusterbuster/reporting/loader/files_loader.py
+++ b/lib/clusterbuster/reporting/loader/files_loader.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .ClusterBusterLoader import LoadOneReport
+from .ClusterBusterLoader import ClusterBusterLoadOneReportBase
 
 
-class files_loader(LoadOneReport):
+class files_loader(ClusterBusterLoadOneReportBase):
     def __init__(self, name: str, report: dict, data: dict, extras=None):
         super().__init__(name, report, data, extras=extras)
 

--- a/lib/clusterbuster/reporting/loader/uperf_loader.py
+++ b/lib/clusterbuster/reporting/loader/uperf_loader.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .ClusterBusterLoader import LoadOneReport
+from .ClusterBusterLoader import ClusterBusterLoadOneReportBase
 
 
-class uperf_loader(LoadOneReport):
+class uperf_loader(ClusterBusterLoadOneReportBase):
     def __init__(self, name: str, report: dict, data: dict, extras=None):
         super().__init__(name, report, data, extras=extras)
 

--- a/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
+++ b/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
@@ -36,24 +36,27 @@ class ClusterBusterReporterException(ClusterBusterReportingException):
         super().__init__(args)
 
 
-class ClusterBusterReporterJobMismatchException(ClusterBusterReporterException):
+class _ClusterBusterReporterJobMismatchException(ClusterBusterReporterException):
     def __init__(self, var: str, val1, val2):
         super().__init__(f"Mismatched {var} in status ({val1} vs {val2})")
 
 
-class ClusterBusterBadReportException(ClusterBusterReportingException):
+class _ClusterBusterBadReportException(ClusterBusterReportingException):
     def __init__(self, item):
-        super().__init__(f"{item} is not a ClusterBuster report")
+        if item is None:
+            super().__init__("No ClusterBuster report found")
+        else:
+            super().__init__(f"{item} is not a ClusterBuster report")
 
 
-class ClusterBusterUnrecognizedWorkloadException(ClusterBusterReportingException):
+class _ClusterBusterUnrecognizedWorkloadException(ClusterBusterReportingException):
     def __init__(self, item):
         super().__init__(f"{item}: cannot identify workload")
 
 
-class ClusterBusterUnrecognizedItemException(ClusterBusterReportingException):
+class _ClusterBusterUnrecognizedItemException(ClusterBusterReportingException):
     def __init__(self, item):
-        super().init__(f"Unrecognized item {item}")
+        super().__init__(f"Unrecognized item {item}")
 
 
 class ClusterBusterReporter:
@@ -69,7 +72,7 @@ class ClusterBusterReporter:
         except KeyError:
             pass
         if not isValid:
-            raise ClusterBusterBadReportException(item)
+            raise _ClusterBusterBadReportException(item)
         jdata['metadata']['RunArtifactDir'] = item
         if report_format == 'none' or report_format is None:
             return
@@ -85,7 +88,7 @@ class ClusterBusterReporter:
             try:
                 workload = jdata["metadata"]["workload"]
             except KeyError:
-                raise ClusterBusterUnrecognizedWorkloadException(item)
+                raise _ClusterBusterUnrecognizedWorkloadException(item)
         if 'runtime_class' not in jdata['metadata']:
             try:
                 runtime_class = jdata['metadata']['options']['runtime_classes'].get('default')
@@ -178,7 +181,8 @@ class ClusterBusterReporter:
             elif isinstance(item, dict):
                 jdata = item
             else:
-                raise ClusterBusterUnrecognizedItemException(f"Unrecognized item {item}")
+                print(item)
+                raise _ClusterBusterUnrecognizedItemException(item)
             answers.append(ClusterBusterReporter.report_one(None, jdata, report_format, extras=extras))
         return answers
 

--- a/lib/clusterbuster/workloads/byo.workload
+++ b/lib/clusterbuster/workloads/byo.workload
@@ -20,7 +20,7 @@
 
 declare -ag ___byo_args=()
 declare -ag ___byo_files=()
-declare -g ___byo_workdir=/var/tmp/clusterbuster/cb-work
+declare -g ___byo_workdir=/var/opt/clusterbuster/cb-work
 declare -g ___byo_workload=
 declare -g ___byo_name=
 declare -ig ___byo_drop_cache=0

--- a/lib/clusterbuster/workloads/files.workload
+++ b/lib/clusterbuster/workloads/files.workload
@@ -101,7 +101,7 @@ function files_process_options() {
     if (( ___file_block_size <= 0)) ; then
 	___file_block_size=___file_size
     fi
-    [[ -z "${___files_dirs[*]}" ]] && ___files_dirs=(/var/tmp/clusterbuster)
+    [[ -z "${___files_dirs[*]}" ]] && ___files_dirs=(/var/opt/clusterbuster)
 }
 
 function files_requires_drop_cache() {

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -28,7 +28,7 @@ declare -ag ___fio_ioengines=(libaio)
 declare -g  ___fio_job_file=generic.jobfile
 declare -gi ___fio_ramp_time=5
 declare -gi ___fio_filesize=; ___fio_filesize=$(parse_size "4Gi")
-declare -g  ___fio_workdir="/var/tmp/clusterbuster"
+declare -g  ___fio_workdir="/var/opt/clusterbuster"
 declare -g  ___fio_processed_job_file
 declare -ig  ___fio_drop_cache=1
 


### PR DESCRIPTION
- Clusterbuster:
  - Use /var/opt/clusterbuster rather than /var/tmp/clusterbuster as work directory (including default mounted volumes).  This better comports with the Filesystem Hierarchy Standard and avoids apparent issues with selinux labeling on /var/tmp that gets inherited.
  - Expand %r and %i in all uses of volume names (some, in particular volume mounts and VM mkfs, were previously missed).
  - Report which invalid option triggered failure.
  - Save the system and user configmaps in the artifacts directory.
  - Try harder to clean up leftover storage for fio and files client (important when using a PVC for storage, since otherwise it doesn't get cleaned up)
  - Set the desired containerdisk image for VMs.
- Perf CI suite:
  - Allow repeated use of -n; -n -n runs clusterbuster with -n, so it's possible to observe what will be done in more detail.
- Clusterbuster reporting:
  - Catch exceptions in analyze-clusterbuster-report.
  - Report average and max latency for fio.
  - Allow combining results for different runs without requiring --allow-mismatch.