### PR TITLE
Miscellaneous improvements

### DIFF
--- a/clusterbuster
+++ b/clusterbuster
@@ -122,6 +122,8 @@ declare -i objs_item_count=0
 declare -i port=7777
 declare -i sync_port=7778
 declare -i drop_cache_port=7779
+declare -i sync_watchdog_port_num=7780
+declare -i sync_watchdog_timeout=0
 declare -i sync_ns_port=7753
 declare -i sync_in_first_namespace=0
 declare sync_host=
@@ -256,6 +258,7 @@ declare -i vm_cores=1
 declare -i vm_threads=1
 declare -i vm_sockets=1
 declare -i vm_start_running=1
+declare vm_run_strategy=
 declare vm_memory=2Gi
 declare vm_grace_period=30
 declare vm_image='quay.io/rkrawitz/clusterbuster-vm:latest'
@@ -274,6 +277,7 @@ OC=${OC:-$(type -p oc)}
 OC=${OC:-$(type -p kubectl)}	# kubectl might not work, though...
 OC=$(type -p "$OC")
 
+declare __virtctl_local_ssh=UNKNOWN
 declare VIRTCTL=${VIRTCTL:-$(type -p virtctl)}
 
 function fatal() {
@@ -391,6 +395,12 @@ Extended Options:
                         architecture of this platform.
        --containerimage=<image>
                         Use the specified container image.
+       --sync_watchdog_timeout=<timeout>
+                        Set watchdog timer for all pods/VMs.  After pods/VMs
+                        start, if the watchdog is not reset within the
+                        timeout, the run is aborted.  Currently not set
+                        (timeout = 0); if set to a value greater than
+                        zero, that is the watchdog period.
 
     Reporting Options:
        --report=<format>
@@ -651,6 +661,11 @@ $(print_workloads_supporting_reporting '                        - ')
                         is generated.
        --vm-run-as-root=[0,1]
                         Run test command as root.  Default $vm_run_as_root.
+       --vm-start-running=[0,1]
+                        Start the VMs in running state (otherwise are started
+                        separately).  Default $vm_start_running.
+       --vm-run_strategy=<strategy>
+                        Specify the desired run strategy for VMs.
 
     Tuning object creation (short equivalents):
        --scale-ns=[0,1] Scale up the number of namespaces vs.
@@ -900,6 +915,7 @@ function process_option() {
 	basename)		    basename=$optvalue				;;
 	arch)			    arch=$optvalue				;;
 	createnamespacesonly)	    create_namespaces_only=1			;;
+	watchdogtimeout)	    watchdog_timeout=$(parse_size "$optvalue")  ;;
 	# Object definition
 	workdir)		    common_workdir=$optvalue			;;
 	configmapfile)		    configmap_files+=("$optvalue")		;;
@@ -980,6 +996,8 @@ function process_option() {
 	vmpassword)		    vm_password=$optvalue			;;
 	vmrunasroot)		    vm_run_as_root=$(bool "$optvalue")		;;
 	vmsshkey*)		    vm_ssh_keyfile=$optvalue			;;
+	vmstart*)		    vm_start_running=$(bool "$optvalue")	;;
+	vmrunstrategy)		    vm_run_strategy="$optvalue"			;;
 	# Object creation
 	obj*spercall)		    objs_per_call=$optvalue			;;
 	parallel)		    parallel=$optvalue				;;
@@ -1235,10 +1253,35 @@ function _____OC() {
     exec "$OC" "$@"
 }
 
+# Newer versions of virtctl need --local-ssh to force virtctl to use the local
+# ssh/scp, which is required to use options to shut off unauthenticated host
+# messages which require interaction.  Some older versions of virtctl, such as
+# the version in Fedora 38, do not accept this option.
+#
+# There's no obvious "clean" way to determine what's needed.  According to the
+# virtctl change log, this was introduced around 0.56, but Fedora 38 has
+# 0.58.1 and does not accept this option.
+function _VIRTCTL_BASE() {
+    local subcmd=${1:-}
+    shift
+    if [[ $subcmd = ssh || $subcmd = scp ]] ; then
+	if [[ $__virtctl_local_ssh = UNKNOWN ]] ; then
+	    if virtctl ssh --help </dev/null 2>&1 |grep -q -e '--local-ssh[= \t]' ; then
+		__virtctl_local_ssh=--local-ssh
+	    else
+		__virtctl_local_ssh=
+	    fi
+	fi
+	"$VIRTCTL" "$subcmd" ${__virtctl_local_ssh:+"$__virtctl_local_ssh"} "$@"
+    else
+	"$VIRTCTL" "$subcmd" "$@"
+    fi
+}
+
 function __VIRTCTL() {
     if ((doit)) ; then
 	debug kubectl "$VIRTCTL" "$@"
-	"$VIRTCTL" "$@"
+	_VIRTCTL_BASE "$@"
     else
 	echo '(skipped)' "$VIRTCTL" "${@@Q}" 1>&2
     fi
@@ -1256,7 +1299,7 @@ function ___VIRTCTL() {
 
 function ____VIRTCTL() {
     debug kubectl "$VIRTCTL" "$@"
-    "$VIRTCTL" "$@"
+    _VIRTCTL_BASE "$@"
 }
 
 function _____VIRTCTL() {
@@ -1632,7 +1675,7 @@ function _monitor_pods() {
 	    unset "starting_pods[$pod]"
 	    unset "running_pods[$pod]"
 	    case "$lstatus" in
-		error|failed)
+		error|failed|oomkilled)
 		    echo "Pod -n $namespace $name $status!" 1>&2
 		    echo "Tail end of logs:" 1>&2
 		    # TODO: Need to get logs from each container
@@ -1744,7 +1787,7 @@ function _fail_helper()  {
 	local podstatus
 	podstatus=$(____OC get pod -ojsonpath='{.status.phase}' "${sync_pod[@]}" 2>/dev/null)
 	case "$podstatus" in
-	    Succeeded|Terminated|Completed)
+	    Succeeded|Terminated|Completed|OOMKilled)
 		return
 		;;
 	    Running)
@@ -1847,7 +1890,7 @@ function _get_sync_logs_poll() {
 		pod_status_found=1
 		sleep 1
 		;;
-	    Error|Failed)
+	    Error|Failed|OOMKilled)
 		pod_status_found=1
 		set_run_failed "Status of pod $pod failed!"
 		return 1
@@ -1888,7 +1931,7 @@ function _get_sync_logs_poll() {
 function get_sync_logs_poll() {
     local tfile
     tfile=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs.XXXXXXXXXX') || fatal "Cannot create temporary file"
-    trap 'retrieve_successful_logs=1 _retrieve_artifacts 1; if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then rm -f "$tfile"; unset tfile; fi; echo "Status: Fail"; return 1' INT TERM HUP USR1
+    trap '(retrieve_successful_logs=1 _retrieve_artifacts 1); if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then rm -f "$tfile"; unset tfile; fi; echo "Status: Fail"; return 1' INT TERM HUP USR1
     _get_sync_logs_poll > "$tfile"
     local status=$?
     if ((status == 0)) ; then
@@ -2224,6 +2267,7 @@ function _retrieve_artifacts() {
     local always_retrieve_artifacts=${1:-}
     get_run_started || return 1
     get_run_failed && always_retrieve_artifacts=1
+    trap 'echo "Interrupt received; aborting" 1>&2; exit' INT TERM HUP
     if [[ -n "$artifactdir" && ! -f "$artifactdir/.artifacts" ]] ; then
 	report_if_desired "Retrieving run artifacts" 1>&2
 	mkdir -p "$artifactdir/Logs"
@@ -2311,7 +2355,7 @@ function _retrieve_artifacts() {
 	    [[ ! -d "$artifactdir/VMLogs" ]] && mkdir "$artifactdir/VMLogs"
 	    while read -r namespace vm ; do
 		# virtctl scp assumes that any colons in the destination filename are remote.
-		"$VIRTCTL" scp -i "$vm_ssh_keyfile" -t "-oStrictHostKeyChecking=no" -t "-oGlobalKnownHostsFile=/dev/null" -t "-oUserKnownHostsFile=/dev/null" -t "-oLogLevel ERROR" "root@$vm.$namespace:/var/log/cloud-init-output.log" "$artifactdir/VMLogs/$namespace.$vm" </dev/null 1>&2 && mv "$artifactdir/VMLogs/$namespace.$vm" "$artifactdir/VMLogs/$namespace:$vm"
+		____VIRTCTL scp -i "$vm_ssh_keyfile" -t "-oBatchMode=yes" -t "-oStrictHostKeyChecking=no" -t "-oGlobalKnownHostsFile=/dev/null" -t "-oUserKnownHostsFile=/dev/null" -t "-oLogLevel ERROR" "root@$vm.$namespace:/var/log/cloud-init-output.log" "$artifactdir/VMLogs/$namespace.$vm" </dev/null 1>&2 && mv "$artifactdir/VMLogs/$namespace.$vm" "$artifactdir/VMLogs/$namespace:$vm"
 	    done <<< "$(__OC get vm -A -l "${basename}-id=$uuid" --no-headers | awk '{print $1, $2}')"
 	fi
     fi
@@ -2626,7 +2670,8 @@ $(indent 2 generate_environment)
 $(if [[ -n "${arglist_function}" ]] ; then
      "${arglist_function}" "${system_configmap_mount_dir}/" "$@" "$container" -- \
      "$sync_nonce" "$namespace" "c$container" "$basetime" "$baseoffset" "$(ts)" "$exit_at_end" "$sync_service" \
-     "$sync_port_num" "$sync_ns_port_num" "$drop_cache_service" "$drop_cache_port_num" | indent 2 ; fi)
+     "$sync_port_num" "$sync_ns_port_num" "$sync_watchdog_port_num" "$sync_watchdog_timeout" \
+     "$drop_cache_service" "$drop_cache_port_num" | indent 2 ; fi)
 $(indent 2 volume_mounts_yaml "$namespace" "${instance}" "$secret_count")
 $(indent 2 <<< "${security_context:-}")
 EOF
@@ -3783,6 +3828,14 @@ EOF
     fi
 }
 
+function _vm_run_yaml() {
+    if [[ -n "$vm_run_strategy" ]] ; then
+	echo "runStrategy: $vm_run_strategy"
+    else
+	echo "running: $vm_running"
+    fi
+}
+
 function create_vm_deployment() {
     get_sysctls
     local node_class=${node_class:-client}
@@ -3835,7 +3888,7 @@ $(indent 2 standard_labels_yaml -c "$node_class" -l "$workload" "$namespace" "$i
   name: "$vmname"
 $(indent 2 standard_deployment_metadata_yaml "$namespace" client)
 spec:
-  running: $vm_running
+$(indent 2 _vm_run_yaml)
   template:
     metadata:
 $(indent 6 standard_labels_yaml -c "$node_class" -l "$workload" "$namespace" "$instance" "$replica")
@@ -3894,7 +3947,8 @@ $(indent 16 _setup_sysctls)
                 - "$(standard_environment -V) $(_run_as_root)  $(_run_as_container)$(if [[ -n "${arglist_function}" ]] ; then
      ARGLIST_FORMAT=vm "${arglist_function}" "${system_configmap_mount_dir}/" "$@" "0" -- \
      "$sync_nonce" "$namespace" "c0" "$basetime" "$baseoffset" "$(ts)" "$exit_at_end" "$sync_service" \
-     "$sync_port_num" "$sync_ns_port_num" "$drop_cache_service" "$drop_cache_port_num" ; fi)"
+     "$sync_port_num" "$sync_ns_port_num" "$sync_watchdog_port_num" "$sync_watchdog_timeout" \
+     "$drop_cache_service" "$drop_cache_port_num" ; fi)"
 EOF
     done
 }
@@ -4050,6 +4104,8 @@ $(indent 2 standard_environment)
   - "$workload_step_interval"
   - "$sync_port"
   - "$sync_ns_port"
+  - "$sync_watchdog_port_num"
+  - "$sync_watchdog_timeout"
   - "$expected_clients"
   - "$initial_expected_clients"
 $(indent 2 volume_mounts_yaml -V "$namespace" 0 0)
@@ -4308,16 +4364,17 @@ function create_all_deployments() {
 }
 
 function create_deployments_post_hook() {
-    if [[ $deployment_type = vm && $vm_start_running -eq 0 ]] ; then
+    if [[ $deployment_type = vm && ($vm_run_strategy != Always || $vm_start_running -eq 0) ]] ; then
 	local namespace
 	local name
 	if [[ -z "$VIRTCTL" ]] ; then
 	    warn "*** Unable to find virtctl command, cannot start VMs!"
 	    return
 	fi
-	while read -r namespace name ; do
+	# shellcheck disable=SC2034
+	while read -r namespace name ignore ; do
 	    "$VIRTCTL" start -n "$namespace" "$name"
-	done < <(__OC get vm -A -l "${basename}-xuuid=$xuuid")
+	done < <(__OC get vm --no-headers -A -l "${basename}-xuuid=$xuuid")
     fi
 }
 
@@ -4827,6 +4884,8 @@ function validate_options() {
     (( !objs_per_call_secrets )) && objs_per_call_secrets=$objs_per_call
     (( !objs_per_call_namespaces )) && objs_per_call_namespaces=$objs_per_call
     (( !objs_per_call_deployments )) && objs_per_call_deployments=$objs_per_call
+
+    (( sync_watchdog_timeout <= 0 )) && sync_watchdog_port_num=0
 
     [[ -n "$report_format" ]] && report=1
 

--- a/lib/clusterbuster/container-image/Dockerfile.workloads
+++ b/lib/clusterbuster/container-image/Dockerfile.workloads
@@ -9,6 +9,7 @@ RUN microdnf --setopt=install_weak_deps=0 --enablerepo=crb install -y \
     microdnf --setopt=install_weak_deps=0 install -y \
       fio \
       fio-engine-libaio \
+      python3-numpy \
       sysbench \
       uperf && \
     microdnf -y clean all && \

--- a/lib/clusterbuster/container-image/firstboot.vm
+++ b/lib/clusterbuster/container-image/firstboot.vm
@@ -14,6 +14,7 @@ dnf install -y \
     fio-engine-libaio \
     procps-ng \
     python3 \
+    python3-numpy \
     sysbench \
     uperf \
     util-linux

--- a/lib/clusterbuster/pod_files/cb_util.py
+++ b/lib/clusterbuster/pod_files/cb_util.py
@@ -51,10 +51,10 @@ class cb_util:
         """
         return self.__initial_connect_time
 
-    def _ts(self):
-        return datetime.utcfromtimestamp(time.time() - self.__offset).strftime('%Y-%m-%dT%T.%f')
+    def _ts(self, t=None):
+        return datetime.utcfromtimestamp((t if t is not None else time.time()) - self.__offset).strftime('%Y-%m-%dT%T.%f')
 
-    def _get_timestamp(self, string):
+    def _get_timestamp(self, string: str = ''):
         """
         Return a string with a timestamp prepended to the first line
         and any other lines indented
@@ -152,7 +152,7 @@ class cb_util:
         elif arg is None:
             return 0
         elif isinstance(arg, str):
-            m = re.match(r'(-?[0-9]+(\.[0-9]+)?)(([kmgt]?)(i?)(b?)?)?', arg.lower())
+            m = re.match(r'(-?[0-9]+(\.[0-9]+)?)(([kmgtpezy]?)(i?)(b?)?)?', arg.lower())
             if m:
                 mantissa = float(m.group(1))
                 modifier = m.group(4)
@@ -166,6 +166,14 @@ class cb_util:
                     base = 3
                 elif modifier == 't':
                     base = 4
+                elif modifier == 'p':
+                    base = 5
+                elif modifier == 'e':
+                    base = 6
+                elif modifier == 'z':
+                    base = 7
+                elif modifier == 'y':
+                    base = 8
                 if binary:
                     return int(mantissa * (1024 ** base))
                 else:

--- a/lib/clusterbuster/reporting/prettyprint.py
+++ b/lib/clusterbuster/reporting/prettyprint.py
@@ -30,7 +30,8 @@ def fformat(num: float, precision: int = 5):
 
 
 def prettyprint(num: float, precision: int = 5, integer: int = 0, base: int = None,
-                suffix: str = '', multiplier: float = 1, parseable: bool = False):
+                suffix: str = '', multiplier: float = 1, parseable: bool = False,
+                use_small_units: bool = True):
     """
     Return a pretty printed version of a number.
     Base 100:  print percent
@@ -85,7 +86,13 @@ def prettyprint(num: float, precision: int = 5, integer: int = 0, base: int = No
         base = 1024
     elif base != -10 or base != -1 or base != -1000:
         raise ValueError(f'Illegal base {base} for prettyprint; must be 1000 or 1024')
-    if base > 0 and abs(num) >= base ** 5:
+    if base > 0 and abs(num) >= base ** 8:
+        return f'{fformat(num / (base ** 8), precision=precision)} Y{infix}{suffix}'
+    elif base > 0 and abs(num) >= base ** 7:
+        return f'{fformat(num / (base ** 7), precision=precision)} Z{infix}{suffix}'
+    elif base > 0 and abs(num) >= base ** 6:
+        return f'{fformat(num / (base ** 6), precision=precision)} E{infix}{suffix}'
+    elif base > 0 and abs(num) >= base ** 5:
         return f'{fformat(num / (base ** 5), precision=precision)} P{infix}{suffix}'
     elif base > 0 and abs(num) >= base ** 4:
         return f'{fformat(num / (base ** 4), precision=precision)} T{infix}{suffix}'
@@ -95,15 +102,23 @@ def prettyprint(num: float, precision: int = 5, integer: int = 0, base: int = No
         return f'{fformat(num / (base ** 2), precision=precision)} M{infix}{suffix}'
     elif base > 0 and abs(num) >= base ** 1:
         return f'{fformat(num / base, precision=precision)} K{infix}{suffix}'
-    elif abs(num) >= 1 or num == 0:
+    elif abs(num) >= 1 or num == 0 or not use_small_units:
         if integer:
             precision = 0
         return f'{fformat(num, precision=precision)} {suffix}'
     elif abs(num) >= 10 ** -3:
-        return f'{fformat(num * (1000), precision=precision)} m{suffix}'
+        return f'{fformat(num * (1000 ** 1), precision=precision)} m{suffix}'
     elif abs(num) >= 10 ** -6:
         return f'{fformat(num * (1000 ** 2), precision=precision)} u{suffix}'
     elif abs(num) >= 10 ** -9:
         return f'{fformat(num * (1000 ** 3), precision=precision)} n{suffix}'
-    else:
+    elif abs(num) >= 10 ** -12:
         return f'{fformat(num * (1000 ** 4), precision=precision)} p{suffix}'
+    elif abs(num) >= 10 ** -15:
+        return f'{fformat(num * (1000 ** 5), precision=precision)} f{suffix}'
+    elif abs(num) >= 10 ** -18:
+        return f'{fformat(num * (1000 ** 6), precision=precision)} a{suffix}'
+    elif abs(num) >= 10 ** -21:
+        return f'{fformat(num * (1000 ** 7), precision=precision)} z{suffix}'
+    else:
+        return f'{fformat(num * (1000 ** 8), precision=precision)} y{suffix}'

--- a/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
+++ b/lib/clusterbuster/reporting/reporter/ClusterBusterReporter.py
@@ -422,7 +422,10 @@ class ClusterBusterReporter:
         return len(self._rows)-1
 
     def _get_metric_value(self, metric_name: str, time: float, selector: dict = None):
-        return self.metrics.get_value_by_key(metric_name, time, selector)
+        try:
+            return self.metrics.get_value_by_key(metric_name, time, selector)
+        except AttributeError:
+            return None
 
     def __format_memory_value(self, number):
         return self._prettyprint(number, precision=3, suffix='B')
@@ -431,7 +434,8 @@ class ClusterBusterReporter:
         return self._prettyprint(number, precision=3, base=1000, suffix='B/sec')
 
     def __format_pkt_rate_value(self, number):
-        return self._prettyprint(number, precision=3, base=1000, suffix='pkts/sec')
+        return self._prettyprint(number, precision=3, base=1000, suffix='pkts/sec',
+                                 use_small_units=False)
 
     def __format_cpu_value(self, number):
         return self._prettyprint(number, precision=3, base=100, suffix='%')
@@ -604,7 +608,7 @@ class ClusterBusterReporter:
         """
         return fformat(num, precision=precision)
 
-    def _prettyprint(self, num: float, precision: float = 5, integer: int = 0, base: int = 1024, suffix: str = ''):
+    def _prettyprint(self, num: float, base: int = 1024, **kwargs):
         """
         Return a pretty printed version of a float.
         Base 100:  print percent
@@ -625,8 +629,7 @@ class ClusterBusterReporter:
             return num
         if base is None:
             base = 1024
-        return prettyprint(num, precision=precision, integer=integer, base=base, suffix=suffix,
-                           parseable='parseable' in self._format)
+        return prettyprint(num, base=base, parseable='parseable' in self._format, **kwargs)
 
     def _safe_div(self, num: float, denom: float, precision: int = None, as_string: bool = False,
                   number_only: bool = False):

--- a/lib/clusterbuster/workloads/memory.workload
+++ b/lib/clusterbuster/workloads/memory.workload
@@ -55,8 +55,9 @@ function memory_help_options() {
                         are provided, a random value between the two
                         is used for each iteration.  Step allows specifying
                         the step size.
-       --memory-scan=<0,1>
-                        Write scan memory continuously
+       --memory-scan=<0,1,random>
+                        Write-scan memory continuously.  "Random" results
+                        in pages being scanned in random order.
        --memory-stride=<size>
                         Stride the specified number of bytes
                         when scanning.  Default is system pagesize.
@@ -100,6 +101,14 @@ function memory_help_options() {
 EOF
 }
 
+function ___memory_scan_order() {
+    local optvalue="${1:-}"
+    case "${optvalue,,}" in
+	rand*) echo 2 		;;
+	*)     bool "$optvalue" ;;
+    esac
+}
+
 function memory_process_options() {
     local opt
     local -a unknown_opts=()
@@ -107,7 +116,7 @@ function memory_process_options() {
 	read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
 	case "$noptname1" in
 	    memorysize)		 ___memory_size=$(parse_size -d, "$optvalue")		  ;;
-	    memoryscan)		 ___memory_scan=$(bool "$optvalue")			  ;;
+	    memoryscan)		 ___memory_scan=$(___memory_scan_order "$optvalue")	  ;;
 	    memorystride*)	 ___memory_stride=$(parse_size "$optvalue")		  ;;
 	    memoryiterations)    ___memory_iterations=$(parse_size "$optvalue")		  ;;
 	    memoryiterationrun*) ___memory_iteration_runtime=$(parse_size -d, "$optvalue");;
@@ -122,6 +131,7 @@ function memory_process_options() {
     if [[ -n "${unknown_opts[*]:-}" ]] ; then
 	warn "Notice: the following options are not known: ${unknown_opts[*]}"
     fi
+    container_image="quay.io/rkrawitz/clusterbuster-workloads:latest"
 }
 
 function memory_report_options() {

--- a/prom-extract
+++ b/prom-extract
@@ -41,20 +41,11 @@ try:
     import urllib3
     import uuid
     import yaml
+    import openshift_client
 except (KeyboardInterrupt, BrokenPipeError):
     efail('')
 except ModuleNotFoundError as exc:
     efail(f"prom-extract failed: {exc}")
-
-# Both openshift and openshift_client provide packages named openshift.
-# Make sure that we have the correct one.
-try:
-    import openshift
-    _ = openshift.project
-except (KeyboardInterrupt, BrokenPipeError):
-    efail('')
-except (ModuleNotFoundError, AttributeError) as exc:
-    efail(f"prom-extract failed: {exc} (need to install Python 'openshift_client', not 'openshift')")
 
 
 def run_command(cmd, fail_on_bad_status=True, report_stderr_async=True,
@@ -98,8 +89,8 @@ def run_command(cmd, fail_on_bad_status=True, report_stderr_async=True,
 
 def get_prometheus_default_url():
     try:
-        with openshift.project('openshift-monitoring'):
-            return 'https://%s' % openshift.selector(['route/prometheus-k8s']).objects()[0].as_dict()['spec']['host']
+        with openshift_client.project('openshift-monitoring'):
+            return 'https://%s' % openshift_client.selector(['route/prometheus-k8s']).objects()[0].as_dict()['spec']['host']
     except (KeyboardInterrupt, BrokenPipeError):
         efail('')
     except Exception as err:
@@ -107,12 +98,12 @@ def get_prometheus_default_url():
 
 
 def get_prometheus_token_by_version():
-    with openshift.project('openshift-monitoring'):
-        openshift_version = openshift.get_server_version().split('-')[0].split('.')
+    with openshift_client.project('openshift-monitoring'):
+        openshift_version = openshift_client.get_server_version().split('-')[0].split('.')
         if int(openshift_version[0]) > 4 or (int(openshift_version[0]) == 4 and int(openshift_version[1]) > 10):
-            return openshift.invoke('sa', ['new-token', '-n', 'openshift-monitoring', 'prometheus-k8s']).out().strip()
+            return openshift_client.invoke('sa', ['new-token', '-n', 'openshift-monitoring', 'prometheus-k8s']).out().strip()
         else:
-            return openshift.get_serviceaccount_auth_token('prometheus-k8s')
+            return openshift_client.get_serviceaccount_auth_token('prometheus-k8s')
 
 
 def get_prometheus_token():
@@ -129,8 +120,8 @@ def get_prometheus_timestamp():
     while retries > 0:
         retries = retries - 1
         try:
-            with openshift.project('openshift-monitoring'):
-                result = openshift.selector('pod/prometheus-k8s-0').object().execute(['date', '+%s.%N'],
+            with openshift_client.project('openshift-monitoring'):
+                result = openshift_client.selector('pod/prometheus-k8s-0').object().execute(['date', '+%s.%N'],
                                                                                      container_name='prometheus')
                 return datetime.fromtimestamp(float(result.out()), timezone.utc)
         except (KeyboardInterrupt, BrokenPipeError):
@@ -144,7 +135,7 @@ def get_prometheus_timestamp():
 
 def get_nodes():
     try:
-        return json.loads([n.as_dict() for n in openshift.selector(['node']).objects()])
+        return json.loads([n.as_dict() for n in openshift_client.selector(['node']).objects()])
     except (KeyboardInterrupt, BrokenPipeError):
         efail('')
     except Exception as err:
@@ -156,7 +147,7 @@ def generate_uuid():
 
 
 def get_object(kind, name):
-    return openshift.selector('%s/%s' % (kind, name)).objects()[0].as_dict()
+    return openshift_client.selector('%s/%s' % (kind, name)).objects()[0].as_dict()
 
 
 try:
@@ -282,7 +273,7 @@ try:
                             bad_object = True
                     if not bad_object:
                         try:
-                            with openshift.project(api_object['namespace']):
+                            with openshift_client.project(api_object['namespace']):
                                 try:
                                     apiobj = get_object(api_object['kind'], api_object['name'])
                                     if apiobj is not None:
@@ -342,8 +333,8 @@ try:
                 'jobStart': startTime.isoformat(timespec='seconds'),
                 'jobEnd': endTime.isoformat(timespec='seconds'),
                 'uuid': args.uuid,
-                'cluster_version': openshift.get_server_version(),
-                'nodes': [n.as_dict() for n in openshift.selector('nodes').objects()],
+                'cluster_version': openshift_client.get_server_version(),
+                'nodes': [n.as_dict() for n in openshift_client.selector('nodes').objects()],
                 'command': args.command,
             },
             'rundata': {


### PR DESCRIPTION
- BUGFIX: compatibility with older and newer versions of virtctl ssh (newer ones need --local-ssh to apply ssh options from command line, older ones don't allow that)
- BUGFIX: Detect OOM kill and treat it as failed completion
- BUGFIX: don't fail in reporting if metrics data is not present
- Retrieve logs more robustly
- --vm-start-running option (missing)
- --vm-run-strategy (preferred way to define whether/how to start VMs)
- --sync-watchdog-timeout (pods/VMs check in periodically with sync so it can detect if anything fails)
- Sync checks for duplicate requests if pod/VM gets restarted
- Sync prints more information about requests
- Allow pod timestamps referenced to other than adjusted time
- Add peta, exa, zetta, yotta, remto, atto, zepto, and yocto prefixes for prettyprint
- Add prettyprint option to use only prefixes >1 where milli, micro, etc. don't make a lot of sense
- Memory workload uses finer grained time check than scanning entire memory block: checks every 1000 pages
- --memory-scan=random to scan in random order
- Memory page count suffix changed from 'it' to 'pp'
- Update prom-extract for latest openshift_client package, which was renamed from 'openshift' thereby resolving an ambiguity.
- Add numpy to the apps image for memory.py.