### PR TITLE
ocp4-upi-util should not require KUBECONFIG to be set

### DIFF
--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -1852,11 +1852,6 @@ done
 
 shift $((OPTIND-1))
 
-if [[ -z "${KUBECONFIG:-}" ]] ; then
-    echo "KUBECONFIG must be set (recommend $HOME/ocp4-upi-install-1/auth/kubeconfig)"
-    exit 1
-fi
-
 if [[ ${command##*/} = ocp4-upi-util ]] ; then
     (( $# >= 1 )) || __usage
     command=${1##*/}


### PR DESCRIPTION
If KUBECONFIG is not set, ocp4-upi-util should just rely on the default assumed by OpenShift.