### PR TITLE
Memory workload improvements and other minor fixes

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -546,11 +546,10 @@ function _check_ci_option() {
     local workload=$2
     local runtime=$3
     if [[ $noptname = *':'* && (-n "$workload" || -n "$runtime") ]] ; then
-	local optbase=
+	local _optbase=
 	local optworkload=
 	local optruntime=
-	# shellcheck disable=SC2034
-	IFS=: read -r optbase optworkload optruntime <<< "$noptname"
+	IFS=: read -r _optbase optworkload optruntime <<< "$noptname"
 	if [[ (-z "$workload" || -z "$optworkload" || $workload = "$optworkload") &&
 		  (-z "$runtime" || -z "$optruntime" || $runtime = "$optruntime") ]] ; then
 	    true
@@ -663,7 +662,6 @@ function process_option() {
     local noptname1
     local optvalue
     local workload
-    # shellcheck disable=SC2034
     read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$option")"
     optvalue=$(splitarg "$optvalue")
     case "$noptname1" in
@@ -712,7 +710,6 @@ function process_workload_options() {
 	local noptname1
 	local optvalue
 	local optworkload
-	# shellcheck disable=SC2034
 	read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$option" "$workload" "$runtimeclass")"
 	if [[ -n "$noptname1" ]] ; then
 	    optvalue=$(splitarg "$optvalue")
@@ -876,7 +873,6 @@ function run_clusterbuster_1() {
     echo "*** Running $jobname at $(date -Is -u)"
     # Runtime class needs to be after any deployment_type argument so
     # that VM will override.
-    # shellcheck disable=SC2090
     doit "$__clusterbuster__" ${dontdoit:+"$dontdoit"} --uuid="$uuid" \
 	 --precleanup --image-pull-policy=IfNotPresent \
 	 --retrieve-successful-logs=1 \

--- a/analyze-clusterbuster-report
+++ b/analyze-clusterbuster-report
@@ -27,11 +27,11 @@ parser = argparse.ArgumentParser(description='Analyze ClusterBuster report')
 analysis_formats = ClusterBusterAnalysis.list_analysis_formats()
 
 parser.add_argument("-o", "--outfile", default=None, type=str, metavar='file', help='Output filename')
-parser.add_argument('--list_formats', action='store_true', help='List available report formats')
-parser.add_argument('--std_report', '--std-report', '--std', action='store_true',
+parser.add_argument("--list_formats", "--list-formats", action='store_true', help='List available report formats')
+parser.add_argument("--std_report", "--std-report", "--std", action='store_true',
                     help='Compare results for standard runtime classes')
-parser.add_argument('--kata', action='store_true', help='Compare results for standard runtime classes')
-parser.add_argument("-r", "--report-type", default=None, type=str, metavar='format',
+parser.add_argument("--kata", action='store_true', help='Compare results for standard runtime classes')
+parser.add_argument("-r", "--report-type", "--report_type", default=None, type=str, metavar='format',
                     choices=analysis_formats, help=f'Analysis format: one of {", ".join(analysis_formats)}')
 parser.add_argument("-w", "--workload", type=str, help='Workloads to process', action='append')
 parser.add_argument("files", metavar='file', type=str, nargs='+', help='Files to process')

--- a/clusterbuster
+++ b/clusterbuster
@@ -66,7 +66,6 @@ fi
 
 # Unfortunate that there's no way to tell shellcheck to always source
 # specific files.
-# shellcheck disable=SC2034
 
 # See the bash change log, differences between 4.4-beta2 and 4.4-rc2:
 # a.  Using ${a[@]} or ${a[*]} with an array without any assigned elements when
@@ -1601,7 +1600,7 @@ function retrieve_prometheus_snapshot() {
     if __OC exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- /bin/sh -c "tar cf - . -C /prometheus --transform 's,^[.],./${promdb_name},' .; true" > "$promdb_path" ; then
 	report_if_desired "Prometheus snapshot retrieved" 1>&2
     else
-	echo "Unable to retrieve Prometheus snapshot" 1>&2
+	timestamp "Unable to retrieve Prometheus snapshot" 1>&2
     fi
 }
 
@@ -1645,8 +1644,6 @@ function _monitor_pods() {
     if [[ -n "${injected_errors[timeout]:-}" ]] ; then
 	warn "*** Injecting forced timeout error"
     fi
-    # shellcheck disable=2034
-    local -i running_pod_count=0
     local -i finished_pod_count=0
     local -i other_pod_count=0
     local -A pod_status=()
@@ -1935,10 +1932,69 @@ function _get_sync_logs_poll() {
     return 0
 }
 
+function generate_emergency_report() {
+    cat <<EOF
+{
+ "Status": "Fail",
+ "metadata": {
+  "kind": "clusterbusterResults",
+  "job_name": "$job_name",
+  "uuid": "$uuid",
+  "workload": "$requested_workload",
+  "workload_reporting_class": "$(_workload_reporting_class)",
+  "command_line": [$(quote_list "${saved_argv[@]}")],
+  "expanded_command_line": [$(quote_list "${processed_options[@]}")],
+  "workload_metadata": {$(indent_hang 1 generate_workload_metadata)},
+  "options": {
+   "basename": "$basename",
+   "containers_per_pod": $containers_per_pod,
+   "deployments_per_namespace": $deps_per_namespace,
+   "namespaces": $namespaces,
+   "bytes_transfer": $bytes_transfer,
+   "bytes_transfer_max": $bytes_transfer_max,
+   "workload_run_time": $workload_run_time,
+   "workload_run_time_max": $workload_run_time_max,
+   "headless_services": $headless_services,
+   "drop_cache": $drop_node_cache,
+   "always_drop_cache": $drop_all_node_cache,
+   "pin_nodes": {$(_report_pin_nodes)},
+   "secrets": $secrets,
+   "replicas": $replicas,
+   "container_image": "$container_image",
+   "node_selector": "$node_selector",
+ $(indent 2 container_resources_json)
+   "runtime_classes": {$(_report_runtime_classes)},
+   "target_data_rate": $target_data_rate,
+   "workload_options": {
+ $(indent 3 call_api -w "$requested_workload" "report_options")
+   }
+  }
+ }
+}
+EOF
+}
+
+function handle_poll_l2_trap() {
+    echo "Artifact retrieval failed; generating emergency report" | timestamp 1>&2
+    generate_emergency_report
+    return 1
+}
+
+function handle_poll_l1_trap() {
+    trap 'handle_poll_l2_trap; return 1' INT TERM HUP USR1
+    echo "Attempting to retrieve artifacts" | timestamp 1>&2
+    (retrieve_successful_logs=1 _retrieve_artifacts 1)
+    if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then
+	rm -f "$tfile"
+	unset tfile
+    fi
+    return 1
+}
+
 function get_sync_logs_poll() {
     local tfile
     tfile=$(mktemp ${cb_tempdir:+-p "$cb_tempdir"} -t '_clusterbusterlogs.XXXXXXXXXX') || fatal "Cannot create temporary file"
-    trap '(retrieve_successful_logs=1 _retrieve_artifacts 1); if [[ -n "${tfile:-}" && -f "$tfile" ]] ; then rm -f "$tfile"; unset tfile; fi; echo "Status: Fail"; return 1' INT TERM HUP USR1
+    trap 'handle_poll_l1_trap; return 1' INT TERM HUP USR1
     _get_sync_logs_poll > "$tfile"
     local status=$?
     if ((status == 0)) ; then
@@ -2180,6 +2236,7 @@ EOF
 }
 
 function _report_failure() {
+    trap - TERM
     cat <<EOF
 {
  "Results": {},
@@ -2233,9 +2290,9 @@ function _describe_entity() {
     local namedesc="$artifactdir/Describe/${3:+$3+}${namespace}:${name}"
     if __OC describe "${entitytype}" -n "$namespace" "$name" > "${namedesc}.tmp" ; then
 	mv "${namedesc}.tmp" "$namedesc"
-	[[ -s "$namedesc" ]] || echo "Warning: empty $entitytype description for ${namespace}:${name}" 1>&2
+	[[ -s "$namedesc" ]] || timestamp "Warning: empty $entitytype description for ${namespace}:${name}" 1>&2
     else
-	echo "Unable to retrieve $entitytype description for ${namespace}:${name}" 1>&2
+	timestamp "Unable to retrieve $entitytype description for ${namespace}:${name}" 1>&2
 	rm -f "${namedesc}.tmp"
 	false
     fi
@@ -2248,9 +2305,14 @@ function _log_container() {
     local clog="$artifactdir/Logs/${namespace}:${pod}:${container}"
     if __OC logs -n "$namespace" "$pod" -c "$container" > "${clog}.tmp" ; then
 	mv "${clog}.tmp" "$clog"
-	[[ -s "$clog" ]] || echo "Warning: empty logs for ${namespace}:${pod}:${container}" 1>&2
+	if [[ ! -s "$clog" ]] ; then
+	    # volumecontainerdisk container logs from VMs are usually empty
+	    if [[ $pod != 'virt-launcher-'* || $container != volumecontainerdisk ]] ; then
+		timestamp "Warning: empty logs for ${namespace}:${pod}:${container}" 1>&2
+	    fi
+	fi
     else
-	echo "Unable to retrieve container log for ${namespace}:${pod}:${container}" 1>&2
+	timestamp "Unable to retrieve container log for ${namespace}:${pod}:${container}" 1>&2
 	rm -f "${clog}.tmp"
 	false
     fi
@@ -2260,11 +2322,13 @@ function _retrieve_vm_xml() {
     local namespace=$1
     local vm=$2
     local clog="$artifactdir/VMXML/${namespace}_${vm}.xml"
-    if __OC exec -n "$namespace" "$(__OC get pod -n "$namespace" -l "vm.kubevirt.io/name=$vm" '-ojsonpath={.items[0].metadata.name}')" -- /bin/sh -c "cat '/var/run/libvirt/qemu/run/${namespace}_${vm}.xml'" > "${clog}.tmp" ; then
+    local podname=
+    podname="$(__OC get pod -n "$namespace" -l "vm.kubevirt.io/name=$vm" '-ojsonpath={.items[0].metadata.name}')"
+    if [[ -n "$podname" ]] && __OC exec -n "$namespace" "$podname" -- /bin/sh -c "cat '/var/run/libvirt/qemu/run/${namespace}_${vm}.xml'" > "${clog}.tmp" ; then
 	mv "${clog}.tmp" "$clog"
-	[[ -s "$clog" ]] || echo "Warning: empty qemu XML file for ${namespace}:${vm}" 1>&2
+	[[ -s "$clog" ]] || timestamp "Warning: empty qemu XML file for ${namespace}:${vm}" 1>&2
     else
-	echo "Unable to retrieve qemu XML file for ${namespace}:${vm}" 1>&2
+	timestamp "Unable to retrieve qemu XML file for ${namespace}:${vm}" 1>&2
 	rm -f "${clog}.tmp"
 	false
     fi
@@ -2274,7 +2338,7 @@ function _retrieve_artifacts() {
     local always_retrieve_artifacts=${1:-}
     get_run_started || return 1
     get_run_failed && always_retrieve_artifacts=1
-    trap 'echo "Interrupt received; aborting" 1>&2; exit' INT TERM HUP
+    trap 'timestamp "Interrupt received; aborting" 1>&2; exit 1' INT TERM HUP
     if [[ -n "$artifactdir" && ! -f "$artifactdir/.artifacts" ]] ; then
 	report_if_desired "Retrieving run artifacts" 1>&2
 	mkdir -p "$artifactdir/Logs"
@@ -2332,11 +2396,10 @@ function _retrieve_artifacts() {
 	    [[ ! -d "$artifactdir/VMXML" ]] && mkdir "$artifactdir/VMXML"
 	    local vm
 	    local entitytype
-	    local ignore
+	    local _ignore
 	    for entitytype in vm vmi ; do
 		jobs_to_wait=()
-		# shellcheck disable=SC2034
-		while read -r namespace vm ignore ; do
+		while read -r namespace vm _ignore ; do
 		    if ((parallel_log_retrieval > 1)) ; then
 			_describe_entity "$namespace" "$vm" "$entitytype"&
 			jobs_pending[$!]=$podname
@@ -2386,6 +2449,12 @@ function get_sync_logs() {
 	    # Even if reporting fails, make sure we capture the JSON
 	    _get_sync_logs "$log_cmd" > "$artifactdir/clusterbuster-report.tmp.json"
 	    status=$?
+	    if [[ ! -f "$artifactdir/clusterbuster-report.tmp.json" ||
+		      ! -s "$artifactdir/clusterbuster-report.tmp.json" ]] ; then
+		echo "Artifact retrieval failed; generating emergency report" | timestamp 1>&2
+		generate_emergency_report > "$artifactdir/clusterbuster-report.tmp.json"
+		status=1
+	    fi
 	    mv "$artifactdir/clusterbuster-report.tmp.json" "$artifactdir/clusterbuster-report.json" &&
 		print_report < "$artifactdir/clusterbuster-report.json"
 	    return $status
@@ -2395,7 +2464,7 @@ function get_sync_logs() {
 	    return $((PIPESTATUS[0] || PIPESTATUS[1]))
 	fi
     else
-	echo "Workload $requested_workload does not support reporting" 1>&2
+	timestamp "Workload $requested_workload does not support reporting" 1>&2
     fi
 }
 
@@ -4269,9 +4338,8 @@ function find_first_deployment() {
     if (( scale_deployments )) ; then
 	local ns
 	local deployment
-	local stuff
-	# shellcheck disable=SC2034
-        while read -r ns deployment stuff ; do
+	local _stuff
+        while read -r ns deployment _stuff ; do
 	    if [[ -n "$deployment" ]] ; then
 		deployment=${deployment#"${ns}"-}
 		deployment=${deployment%-*}
@@ -4381,8 +4449,7 @@ function create_deployments_post_hook() {
 	    warn "*** Unable to find virtctl command, cannot start VMs!"
 	    return
 	fi
-	# shellcheck disable=SC2034
-	while read -r namespace name ignore ; do
+	while read -r namespace name _ignore ; do
 	    "$VIRTCTL" start -n "$namespace" "$name"
 	done < <(__OC get vm --no-headers -A -l "${basename}-xuuid=$xuuid")
     fi
@@ -4417,7 +4484,7 @@ function create_all_objects() {
 	fi
     done < <("create_all_${objtype}" "$@" 2>&1)
     if [[ $(type -t "create_${objtype}_post_hook") = function ]] ; then
-	"create_${objtype}_post_hook" "${objects_created[@]}"
+	"create_${objtype}_post_hook" "${objects_created[@]}" 2>&1 | timestamp 1>&2
     fi
 }
 

--- a/clusterbuster-report
+++ b/clusterbuster-report
@@ -16,7 +16,7 @@
 
 import sys
 import argparse
-from lib.clusterbuster.reporting.reporter.ClusterBusterReporter import ClusterBusterReporter
+from lib.clusterbuster.reporting.reporter.ClusterBusterReporter import ClusterBusterReporter, ClusterBusterReporterException
 import traceback
 import os
 
@@ -26,10 +26,12 @@ if 'CB_LIBPATH' in os.environ:
 parser = argparse.ArgumentParser(description='Generate ClusterBuster report')
 report_formats = ClusterBusterReporter.list_report_formats()
 
-parser.add_argument('-o', '--format', '--output_format', '--output', '--report-format',
+parser.add_argument('-o', '--format', '--output_format', '--output-format', '--output', '--report-format',
+                    '--report_format',
                     default='summary', metavar='format', type=str,
                     choices=report_formats, help=f'Report format: one of {", ".join(report_formats)}')
-parser.add_argument('--list_formats', action='store_true', help='List available report formats')
+parser.add_argument('--list_formats', '--list-formats', action='store_true',
+                    help='List available report formats')
 parser.add_argument("files", metavar='file', type=str, nargs='*', help='Files to process')
 
 args, extras = parser.parse_known_args()
@@ -40,6 +42,9 @@ if args.list_formats:
 try:
     ClusterBusterReporter.print_report(args.files, report_format=args.format, extras=extras)
 except (KeyboardInterrupt, BrokenPipeError):
+    sys.exit(1)
+except ClusterBusterReporterException as exc:
+    print(f"Generating report failed: {exc}")
     sys.exit(1)
 except Exception:
     print(f"Decoding JSON failed: {traceback.format_exc()}", file=sys.stderr)

--- a/lib/clusterbuster/CI/workloads/cpusoaker.ci
+++ b/lib/clusterbuster/CI/workloads/cpusoaker.ci
@@ -51,15 +51,17 @@ function cpusoaker_test_1() {
 			    --replicas="$replicas" --failure-status='No Result' \
 			    --cleanup-always=1 || return
 	counter=$((counter+1))
+	# shellcheck disable=SC2154
 	((debugonly && counter > 10)) && break
     done
 }
 
 function cpusoaker_test() {
     local default_job_runtime=$1
-    local -A runtimes_tested=()
     local runtime
+    # shellcheck disable=SC2154
     for runtime in "${runtimeclasses[@]}" ; do
+	# shellcheck disable=SC2154
 	process_workload_options "$workload" "${runtime:-pod}"
 	if ((___cpusoaker_replica_increment < 1)) ; then
 	    echo "Replica increment must be at least 1" 1>&2
@@ -85,10 +87,10 @@ function cpusoaker_initialize_options() {
 function cpusoaker_process_option() {
     local opt=$1
     local noptname1
-    local noptname
+    local _noptname
     local optvalue
-    # shellcheck disable=SC2034
-    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    read -r noptname1 _noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    # shellcheck disable=SC2207
     case "$noptname1" in
 	'')		    						;;
 	cpusoakerstarting*) ___cpusoaker_starting_replicas=$optvalue	;;

--- a/lib/clusterbuster/CI/workloads/files.ci
+++ b/lib/clusterbuster/CI/workloads/files.ci
@@ -32,7 +32,9 @@ function files_test() {
 	local -i interval=$2
 	echo $((((base + interval - 1) / interval) * interval))
     }
+    # shellcheck disable=SC2154
     for runtimeclass in "${runtimeclasses[@]}" ; do
+	# shellcheck disable=SC2154
 	process_workload_options "$workload" "${runtimeclass:-pod}"
 	___files_job_timeout=$(compute_timeout "$___files_job_timeout")
 	if [[ -z "${___files_params[*]}" ]] ; then
@@ -76,7 +78,7 @@ function files_test() {
 	    if ((bytes_per_file < fs_block_size)) ; then bytes_per_file=fs_block_size; fi
 	    bytes_per_file=$(roundup "$bytes_per_file" "$fs_block_size")
 	    local -i inodes_required=$((1024 + ___files_dirs_per_volume + (___files_dirs_per_volume * ___files_per_dir)))
-	    local -i bytes_required=$(((inodes_required * 256) + (bytes_per_file * ___files_dirs_per_volume * ___files_per_dir)))
+	    local -i bytes_required=$(((inodes_required * inode_size_bytes) + (bytes_per_file * ___files_dirs_per_volume * ___files_per_dir)))
 	    # Add 12.5% overhead and round up to next MB
 	    bytes_required=$(roundup $((bytes_required * 9 / 8)) 1048576)
 	    ((bytes_required < 32 * 1048576)) && bytes_required=$((32 * 1048576))
@@ -133,10 +135,9 @@ function files_initialize_options() {
 function files_process_option() {
     local opt=$1
     local noptname1
-    local noptname
+    local _noptname
     local optvalue
-    # shellcheck disable=SC2034
-    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    read -r noptname1 _noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     # shellcheck disable=SC2206
     case "$noptname1" in
 	'')		 									;;

--- a/lib/clusterbuster/CI/workloads/fio.ci
+++ b/lib/clusterbuster/CI/workloads/fio.ci
@@ -44,8 +44,9 @@ function fio_test() {
 
     local default_job_runtime=$1
     local -i ninst
-    # shellcheck disable=SC2090
+    # shellcheck disable=SC2154
     for runtimeclass in "${runtimeclasses[@]}" ; do
+	# shellcheck disable=SC2154
 	process_workload_options "$workload" "${runtimeclass:-pod}"
 	local -i counter=0
 	for ninst in "${___fio_ninst[@]}" ; do
@@ -107,6 +108,7 @@ function fio_test() {
 		done
 		nvolumes+=("--volume=$(IFS=:; echo "${nargs[*]}")")
 	    done
+	    # shellcheck disable=SC2090
 	    run_clusterbuster_1 -r "$runtimeclass" \
 				-j "$job_name" -w fio -t "$___fio_job_timeout" -R "$___fio_job_runtime" -- \
 				--replicas="$ninst" \
@@ -151,10 +153,9 @@ function fio_initialize_options() {
 function fio_process_option() {
     local opt=$1
     local noptname1
-    local noptname
+    local _noptname
     local optvalue
-    # shellcheck disable=SC2034
-    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    read -r noptname1 _noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     case "$noptname1" in
 	'')		 								;;
 	fioblock*)       readarray -t ___fio_blocksizes <<< "$(parse_size "$optvalue")"	;;

--- a/lib/clusterbuster/CI/workloads/uperf.ci
+++ b/lib/clusterbuster/CI/workloads/uperf.ci
@@ -25,7 +25,9 @@ declare -g ___uperf_use_annotation
 function uperf_test() {
     local default_job_runtime=$1
     local runtimeclass
+    # shellcheck disable=SC2154
     for runtimeclass in "${runtimeclasses[@]}" ; do
+	# shellcheck disable=SC2154
 	process_workload_options "$workload" "${runtimeclass:-pod}"
 	if ((___uperf_job_runtime <= 0)) ; then
 	    ___uperf_job_runtime=$default_job_runtime
@@ -71,10 +73,9 @@ function uperf_initialize_options() {
 function uperf_process_option() {
     local opt=$1
     local noptname1
-    local noptname
+    local _noptname
     local optvalue
-    # shellcheck disable=SC2034
-    read -r noptname1 noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
+    read -r noptname1 _noptname optvalue <<< "$(parse_ci_option "$opt" "$workload" "${runtimeclass:-pod}")"
     case "$noptname1" in
 	'')	       										;;
 	uperfmsg*)     readarray -t ___uperf_msg_sizes <<< "$(parse_size "$optvalue")"		;;
@@ -89,6 +90,7 @@ function uperf_process_option() {
 }
 
 function uperf_help_options() {
+    # shellcheck disable=SC2154
     cat <<EOF
     Uperf test options:
         --uperf-msg-sizes=n[,n...]

--- a/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
+++ b/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
@@ -311,9 +311,11 @@ class clusterbuster_pod_client(cb_util):
                 answer[key] = val
         self._timestamp(f"Report results: {self._namespace()}, {self._podname()}, {self._container()}, {os.getpid()}")
         try:
-            answer = json.dumps(self._clean_numbers(answer))
-        except Exception as exc:
+            answer = json.dumps(self._sanitize_json(answer))
+        except TypeError as exc:
             self.__fail(f"Cannot convert results to JSON: {exc}")
+        except Exception as exc:
+            self.__fail(f"Unexpected error when converting results to JSON: {exc}")
         self.__do_sync_command('RSLT', answer)
         self.__reported_results = True
 

--- a/lib/clusterbuster/pod_files/fio.py
+++ b/lib/clusterbuster/pod_files/fio.py
@@ -110,7 +110,8 @@ Drop cache:  {self.fio_drop_cache}""")
                                     command.extend(['--output-format=json+', f'--output={outfile}', jobfile])
                                     success, data, stderr = self._run_command(command)
                                     if not success:
-                                        raise Exception(f'{" ".join(command)} failed: {stderr if stderr != "" else "Unknown error"}')
+                                        err = stderr if stderr != "" else "Unknown error"
+                                        raise Exception(f'{" ".join(command)} failed: {err}')
                                     try:
                                         with open(outfile, mode='r') as f:
                                             data = f.read()

--- a/lib/clusterbuster/pod_files/sync.py
+++ b/lib/clusterbuster/pod_files/sync.py
@@ -367,7 +367,8 @@ def sync_one(sock, tmp_sync_file_base: str, tmp_error_file: str, start_time: flo
                 fail_hard(f"Unexpected command {command} from {address}, expected {expected_command}, payload {payload}")
         else:
             expected_command = command
-        timebase._timestamp(f"Accepted connection from {address}, command {command}, payload {payload if command == 'sync' else len(payload)}")
+        pl = payload if command == 'sync' else len(payload)
+        timebase._timestamp(f"Accepted connection from {address}, command {command}, payload {pl}")
         if command == 'time' or command == 'tnet':
             timebase._timestamp(f"Time request {payload}")
             if first_pass:
@@ -452,7 +453,9 @@ def finish():
 
     try:
         with open(tmp_sync_file_base, 'w') as tmp:
-            tmp.write(json.dumps(timebase._clean_numbers(result), sort_keys=True, indent=1))
+            tmp.write(json.dumps(timebase._sanitize_json(result), sort_keys=True, indent=1))
+    except TypeError as exc:
+        fatal(f"Invalid JSON encountered trying to write to sync file {tmp_sync_file_base}: {exc}")
     except Exception as exc:
         fatal(f"Can't write to sync file {tmp_sync_file_base}: {exc}")
     try:

--- a/lib/clusterbuster/workloads/uperf.workload
+++ b/lib/clusterbuster/workloads/uperf.workload
@@ -64,6 +64,7 @@ function uperf_create_deployment() {
     if ((((replicas * containers_per_pod * processes_per_pod) + 4) > ___uperf_port_addrs)) ; then
 	___uperf_port_addrs=$(((replicas * containers_per_pod * processes_per_pod) + 4))
     fi
+    # shellcheck disable=SC2034
     container_image="quay.io/rkrawitz/clusterbuster-workloads:latest"
     create_sync_service "$namespace" \
 			"$((containers_per_pod * replicas * count))" \
@@ -135,7 +136,6 @@ function uperf_process_options() {
     for opt in "$@" ; do
 	read -r noptname1 noptname optvalue <<< "$(parse_option "$opt")"
 	# shellcheck disable=SC2206
-	# shellcheck disable=SC2034
 	case "$noptname1" in
 	    uperfmsgsize*) ___uperf_msg_sizes=(${optvalue//,/ })   ;;
 	    uperftesttype*) ___uperf_test_types=(${optvalue//,/ }) ;;

--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -816,9 +816,8 @@ function __setup_bm_if() {
     local uuid
     local type
     local device
-    local rest
-    # shellcheck disable=SC2034
-    while read -r name uuid type device rest ; do
+    local _rest
+    while read -r name uuid type device _rest ; do
     	if [[ $name = "$cluster_network_bridge_name" ]] ; then
     	    nmcli con del "$uuid"
     	fi


### PR DESCRIPTION
Improve memory workload:
- Improve report from memory workload
- Generate page rate from active time only
- Fix memory operations rate calculation by using operation start time rather than allocation end time, which does not include the sync prior to operation start and hence is too early leading to too-low numbers.
- Report IOPS rate with summary

Other:
- Timestamp various messages from clusterbuster that weren't before.
- Don't warn about empty log from volumecontainerdisk container
- Rename _clean_numbers to _sanitize_json to better reflect purpose
- Fix most of the line too long flake8's
- Change get_start_and_end to non-static to allow it access to JSON data as a member
- Generate usable emergency report if run is aborted
- Allow more hyphen/underscore combinations with clusterbuster report CLI
- Fail VM XML reporting more cleanly