### PR TITLE
Omnibus fixes and improvements

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -769,7 +769,7 @@ function python_create_venv() {
 	. "$1/bin/activate" || fatal "Can't activate venv!"
 	if ((set_u_works)) ; then set -u; fi
 	python3 -m pip -q install --upgrade pip || fatal "Can't upgrade pip!"
-	pip3 -q install prometheus-api-client==0.5.0 openshift-client==1.0.14 Jinja2==3.0.1 || fatal "Can't install Python packages!"
+	pip3 -q install prometheus-api-client==0.5.0 openshift_client==2.0.4 Jinja2==3.0.1 || fatal "Can't install Python packages!"
     fi
 }
 

--- a/clusterbuster
+++ b/clusterbuster
@@ -228,6 +228,7 @@ declare -i __sysctls_retrieved=0
 
 declare -r sync_flag_file="/tmp/syncfile";
 declare -r sync_error_file="/tmp/syncerror";
+declare -r sync_done_file="/tmp/syncdone";
 declare -r controller_timestamp_file="/tmp/timing.json";
 declare uuid
 uuid=$(uuidgen -r)
@@ -268,6 +269,7 @@ declare vm_user=cluster
 declare vm_password=buster
 declare vm_ssh_keyfile=
 declare -i vm_run_as_root=0
+declare -i vm_block_multiqueue=0
 # Hard code for the time being
 declare -a vm_net_addr=(192 168 129 1)
 
@@ -668,6 +670,9 @@ $(print_workloads_supporting_reporting '                        - ')
                         separately).  Default $vm_start_running.
        --vm-run_strategy=<strategy>
                         Specify the desired run strategy for VMs.
+       --vm-block-multiqueue=<n>
+                        Specify the desired number of I/O threads for block
+                        devices.
 
     Tuning object creation (short equivalents):
        --scale-ns=[0,1] Scale up the number of namespaces vs.
@@ -1004,6 +1009,7 @@ function process_option() {
 	vmsshkey*)		    vm_ssh_keyfile=$optvalue			;;
 	vmstart*)		    vm_start_running=$(bool "$optvalue")	;;
 	vmrunstrategy)		    vm_run_strategy="$optvalue"			;;
+	vmblockmultiq*)		    vm_block_multiqueue=$optvalue		;;
 	# Object creation
 	obj*spercall)		    objs_per_call=$optvalue			;;
 	parallel)		    parallel=$optvalue				;;
@@ -1377,54 +1383,6 @@ function get_drop_cache() {
 # Logging
 ################################################################
 
-# Based on https://gist.github.com/akostadinov/33bb2606afe1b334169dfbf202991d36
-function stack_trace() {
-    local -a stack=()
-    local stack_size=${#FUNCNAME[@]}
-    local -i start=${1:-1}
-    local -i max_frames=${2:-$stack_size}
-    ((max_frames > stack_size)) && max_frames=$stack_size
-    local -i i
-    local -i max_funcname=0
-    local -i stack_size_len=${#max_frames}
-    local -i max_filename_len=0
-    local -i max_line_len=0
-
-    # to avoid noise we start with 1 to skip the stack function
-    for (( i = start; i < max_frames; i++ )); do
-	local func="${FUNCNAME[$i]:-(top level)}"
-	((${#func} > max_funcname)) && max_funcname=${#func}
-	local src="${BASH_SOURCE[$i]:-(no file)}"
-	# Line number is used as a string here, not an int,
-	# since we want the length of it as a string.
-	local line="${BASH_LINENO[$(( i - 1 ))]}"
-	[[ $src = "$__realsc__" ]] && src="$__topsc__"
-	((${#src} > max_filename_len)) && max_filename_len=${#src}
-	((${#line} > max_line_len)) && max_line_len=${#line}
-    done
-    local stack_frame_str="    (%${stack_size_len}d)   %${max_filename_len}s:%-${max_line_len}d  %${max_funcname}s%s"
-    local -i arg_count=${BASH_ARGC[0]}
-    for (( i = start; i < max_frames; i++ )); do
-	local func="${FUNCNAME[$i]:-(top level)}"
-	local -i line="${BASH_LINENO[$(( i - 1 ))]}"
-	local src="${BASH_SOURCE[$i]:-(no file)}"
-	[[ $src = "$__realsc__" ]] && src="$__topsc__"
-	local -i frame_arg_count=${BASH_ARGC[$i]}
-	local argstr=
-	if ((frame_arg_count > 0)) ; then
-	    local -i j
-	    for ((j = arg_count + frame_arg_count - 1; j >= arg_count; j--)) ; do
-		argstr+=" ${BASH_ARGV[$j]}"
-	    done
-	fi
-	# We need a dynamically generated string to get the columns correct.
-	# shellcheck disable=SC2059
-	stack+=("$(printf "$stack_frame_str" "$((i - start))" "$src" "$line" "$func" "${argstr:+ $argstr}")")
-	arg_count=$((arg_count + frame_arg_count))
-    done
-    (IFS=$'\n'; echo "${stack[*]}")
-}
-
 function set_run_started() {
     touch "${cb_tempdir}/___run_started"
 }
@@ -1435,7 +1393,7 @@ function get_run_started() {
 
 function set_run_aborted() {
     echo "Run aborted: ${*:-unknown reason}" 1>&2
-    stack_trace 1>&2
+    stack_trace -q 1>&2
     touch "${cb_tempdir}/___run_aborted"
 }
 
@@ -1455,12 +1413,12 @@ function set_run_failed() {
     if get_run_failed ; then
 	if ! get_run_aborted ; then
 	    echo "Secondary failure: ${*:-unknown reason}" 1>&2
-	    stack_trace 1 3 1>&2
+	    stack_trace -q 1 3 1>&2
 	fi
 	return
     fi
     echo "Run failed: ${*:-unknown reason}" 1>&2
-    stack_trace 1>&2
+    stack_trace -q 1>&2
     echo "${*:-unknown reason}" > "${cb_tempdir}/___run_failed"
     run_on_sync_n sh -c "echo 'Please see logs for details.' >> '$sync_error_file'" || touch "${cb_tempdir}/___run_aborted"
 }
@@ -1799,14 +1757,21 @@ function _fail_helper()  {
 		# oc exec connection from prematurely terminating.
 		# If the flag file exists, we need to exit even if there's
 		# no error flag.
-		faildata="$(run_on_sync_n sh -c "while [[ ! -f '$sync_error_file' && ! -f '$sync_flag_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; cat '$sync_error_file'" 2>/dev/null)"
+		#
+		# The sync_done_file is to avoid a race condition with the
+		# log helper retrieving the flag file and removing it
+		# between iterations of the failure test.  That would result
+		# in the test never exiting.
+		faildata="$(run_on_sync_n sh -c "while [[ ! -f '$sync_error_file' && ! -f '$sync_flag_file' && ! -f '$sync_done_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; if [[ -f '$sync_flag_file' || -f '$sync_done_file' ]] ; then echo '---OK---'; elif [[ -f '$sync_error_file' ]] ; then cat '$sync_error_file'; fi" 2>/dev/null)"
 		if [[ -n "$faildata" ]] ; then
+		    if [[ $faildata = '---OK---' ]] ; then return; fi
 		    set_run_failed "Run failed: ${nl}${faildata:-}"
 		    return
 		fi
+		sleep 1
 		;;
 	    *)
-		sleep 1;
+		sleep 1
 		;;
 	esac
     done
@@ -1840,7 +1805,16 @@ function _log_helper() {
 	# to filter out the status messages, timestamp them and send them back to stderr, and finally
 	# redirect fd 4 back to the temporary file.
 	# If that seems enough to make your head spin...well, it is.
-	if ( (run_on_sync_n sh -c "while [[ ! -f '$sync_flag_file' && ! -f '$sync_error_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; cat '$sync_flag_file'; sleep 5; echo DONE 1>&2") 2>&1 1>&4 | while read -r l; do if [[ $l != KEEPALIVE && $l != DONE ]] ; then echo "$l"; fi; done | timestamp 1>&2) 4> "$tmpfile" &&
+	#
+	# The sleep 5 before exiting appears to be needed because cat'ing the flag file
+	# can sometimes complete quickly, before all of the data has been read out.
+	# When that happens the reader exits before all of the data has been read.
+	# This sleep may not be entirely sufficient; it isn't entirely clear how to be
+	# certain that all of the data has been read before terminating the loop.
+	#
+	# The sync_done_file is to avoid a race condition with the fail helper, as described
+	# above.
+	if ( (run_on_sync_n sh -c "while [[ ! -f '$sync_flag_file' && ! -f '$sync_error_file' ]] ; do sleep 5; echo KEEPALIVE 1>&2; done; if [[ -f '$sync_flag_file' ]] ; then cat '$sync_flag_file'; touch '$sync_done_file'; sleep 5; echo DONE 1>&2; elif [[ -f '$sync_error_file' ]] ; then cat $sync_error_file 1>&2; echo FAILED 1>&2; fi") 2>&1 1>&4 | while read -r l; do if [[ $l != KEEPALIVE && $l != DONE ]] ; then echo "$l"; fi; done | timestamp 1>&2) 4> "$tmpfile" &&
 	       grep -q 'worker_results' "$tmpfile" && jq -c . "$tmpfile" >/dev/null 2>&1 ; then
 	    report_if_desired "Run complete, retrieving results" 1>&2
 	    cat "$tmpfile"
@@ -3910,8 +3884,26 @@ EOF
 function _vm_run_yaml() {
     if [[ -n "$vm_run_strategy" ]] ; then
 	echo "runStrategy: $vm_run_strategy"
+    elif ((vm_start_running)) ; then
+	echo "runStrategy: Always"
     else
-	echo "running: $vm_running"
+	echo "runStrategy: Halted"
+    fi
+}
+
+function _vm_block_multiqueue_cpu() {
+    if ((vm_block_multiqueue > 0)) ; then
+	cat <<EOF
+ioThreadsPolicy: supplementalPool
+ioThreads:
+  supplementalPoolThreadCount: $vm_block_multiqueue
+EOF
+    fi
+}
+
+function _vm_block_multiqueue_disk() {
+    if ((vm_block_multiqueue > 0)) ; then
+	echo "blockMultiQueue: true"
     fi
 }
 
@@ -3930,7 +3922,6 @@ function create_vm_deployment() {
     local drop_cache_port_num=
     local vm_running=true
     local vm_addr
-    ((vm_start_running)) || vm_running=false
     pin_node=$(get_pin_node "$node_class")
     if [[ -z "$affinity_yaml" ]] ; then
 	if [[ -n "${pin_node:-}" ]] ; then
@@ -3984,7 +3975,9 @@ $(indent 6 _vm_evict_strategy)
           threads: $vm_threads
         memory:
           guest: $vm_memory
+$(indent 8 _vm_block_multiqueue_cpu)
         devices:
+$(indent 10 _vm_block_multiqueue_disk)
           disks:
 $(indent 12 _vm_container_disk_yaml)
 $(indent 12 vm_volume_devices_yaml)
@@ -4442,7 +4435,7 @@ function create_all_deployments() {
 }
 
 function create_deployments_post_hook() {
-    if [[ $deployment_type = vm && ($vm_run_strategy != Always || $vm_start_running -eq 0) ]] ; then
+    if [[ $deployment_type = vm && ($vm_run_strategy != Always && $vm_start_running -eq 0) ]] ; then
 	local namespace
 	local name
 	if [[ -z "$VIRTCTL" ]] ; then
@@ -4695,12 +4688,11 @@ function do_logging() {
 }
 
 function report_object_creation() {
-    (( report_object_creation )) || return 0
     local objtype
     while read -r objtype ; do
-	[[ -n "${objtype:-}" ]] && printf "Created %${#total_objects_created}d %s%s\n" "${objects_created[$objtype]}" "$objtype" "${plurals[$((${objects_created[$objtype]} == 1))]}" 1>&2
+	[[ -n "${objtype:-}" ]] && printf "Created %${#total_objects_created}d %s%s\n" "${objects_created[$objtype]}" "$objtype" "${plurals[$((${objects_created[$objtype]} == 1))]}" | timestamp 1>&2
     done < <( (IFS=$'\n'; echo "${!objects_created[*]}") | sort)
-    printf "Created %d object%s total\n" "$total_objects_created" "${plurals[$((total_objects_created == 1))]}" 1>&2
+    printf "Created %d object%s total\n" "$total_objects_created" "${plurals[$((total_objects_created == 1))]}" | timestamp 1>&2
 }
 
 function expand_string() {
@@ -4789,7 +4781,7 @@ function run_clusterbuster_2() {
     set_run_started
 
     do_logging || return 1
-    if ! get_run_failed || ((! status)) ; then
+    if ! get_run_failed || ((! status && report_object_creation )) ; then
 	report_object_creation
     fi
     return 0

--- a/lib/clusterbuster/CI/workloads/fio.ci
+++ b/lib/clusterbuster/CI/workloads/fio.ci
@@ -19,6 +19,7 @@ declare -ga ___fio_patterns
 declare -ga ___fio_directs
 declare -ga ___fio_fdatasyncs
 declare -ga ___fio_iodepths
+declare -ga ___fio_numjobs
 declare -ga ___fio_ioengines
 declare -ga ___fio_ninst
 declare -gi ___fio_job_runtime
@@ -116,6 +117,7 @@ function fio_test() {
 				--fio-patterns="$(IFS=,; echo "${___fio_patterns[*]}")" \
 				--fio-ioengines="$(IFS=,; echo "${___fio_ioengines[*]}")" \
 				--fio-iodepths="$(IFS=,; echo "${___fio_iodepths[*]}")" \
+				--fio-numjobs="$(IFS=,; echo "${___fio_numjobs[*]}")" \
 				--fio-fdatasyncs="$(IFS=,; echo "${___fio_fdatasyncs[*]}")" \
 				--fio-directs="$(IFS=,; echo "${___fio_directs[*]}")" \
 				--fio_filesize="$filesize" \
@@ -135,6 +137,7 @@ function fio_initialize_options() {
     ___fio_directs=(1)
     ___fio_fdatasyncs=(0)
     ___fio_iodepths=(1 4)
+    ___fio_numjobs=(1)
     ___fio_ioengines=(sync libaio)
     ___fio_ninst=(1 4)
     ___fio_job_runtime=0
@@ -163,6 +166,7 @@ function fio_process_option() {
 	fiodirect*)      readarray -t ___fio_directs <<< "$(bool "$optvalue")"		;;
 	fiofdatasync*)   readarray -t ___fio_fdatasyncs <<< "$(bool "$optvalue")"	;;
 	fioiodepth*)     readarray -t ___fio_iodepths <<< "$(parse_size "$optvalue")"	;;
+	fionumjobs*)     readarray -t ___fio_numjobs <<< "$(parse_size "$optvalue")"	;;
 	fioioeng*)       readarray -t ___fio_ioengines <<< "$optvalue"			;;
 	fioninst*)       readarray -t ___fio_ninst <<< "$(parse_size "$optvalue")"	;;
 	fioworkdir)      ___fio_workdir=$optvalue					;;
@@ -201,6 +205,10 @@ function fio_help_options() {
         --fio-iodepths=n[,n...]
                                 Space or comma separated list of I/O depths
                                 to test.  Default is $(IFS=,; echo "${___fio_iodepths[*]}").
+        --fio-numjobs=n[,n...]
+                                Space or comma separated list of number of
+                                jobs to run.
+                                to test.  Default is $(IFS=,; echo "${___fio_numjobs[*]}").
         --fio-ioengines=engine[,engine...]
                                 Space or comma separated list of I/O engines
                                 to use.  Default is $(IFS=,; echo "${___fio_ioengines[*]}").

--- a/lib/clusterbuster/container-image/Makefile
+++ b/lib/clusterbuster/container-image/Makefile
@@ -105,3 +105,6 @@ endif
 	-virsh undefine cnv-containerdisk
 
 FORCE: ;
+
+clean:
+	rm -f *.qcow2

--- a/lib/clusterbuster/pod_files/client.py
+++ b/lib/clusterbuster/pod_files/client.py
@@ -4,7 +4,7 @@ import time
 import random
 import math
 
-from clusterbuster_pod_client import clusterbuster_pod_client
+from clusterbuster_pod_client import clusterbuster_pod_client, ClusterBusterPodClientException
 
 
 class client_client(clusterbuster_pod_client):
@@ -60,7 +60,7 @@ class client_client(clusterbuster_pod_client):
                     nleft -= nwrite
                     data_sent += nwrite
                 else:
-                    raise Exception("Unexpected zero length message sent")
+                    raise ClusterBusterPodClientException("Unexpected zero length message sent")
             nleft = self.msg_size
             read_failures = 0
             while nleft > 0:
@@ -69,7 +69,7 @@ class client_client(clusterbuster_pod_client):
                 except Exception as error:
                     self._timestamp(f"Read failed: {error}")
                     if read_failures > 2:
-                        raise error
+                        raise ClusterBusterPodClientException(error)
                     else:
                         read_failures += 1
                         continue
@@ -78,7 +78,7 @@ class client_client(clusterbuster_pod_client):
                 if nread > 0:
                     nleft -= nread
                 else:
-                    raise Exception("Unexpected zero length msg received")
+                    raise ClusterBusterPodClientException("Unexpected zero length msg received")
             en = self._adjusted_time() - rtt_start - time_overhead
             ex += en
             ex2 += en * en

--- a/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
+++ b/lib/clusterbuster/pod_files/clusterbuster_pod_client.py
@@ -28,6 +28,11 @@ import shutil
 from cb_util import cb_util
 
 
+class ClusterBusterPodClientException(Exception):
+    def __init__(self, *args):
+        super().__init__('\n'.join([str(arg) for arg in args]))
+
+
 class clusterbuster_pod_client(cb_util):
     """
     Python interface to the ClusterBuster pod API
@@ -158,6 +163,8 @@ class clusterbuster_pod_client(cb_util):
                                                  user, system, {'Note': 'No results provided'})
                         self._timestamp(f"Process {i} (pid {os.getpid()}) complete")
                         self.__finish()
+                    except ClusterBusterPodClientException as err:
+                        self.__finish(False, message=err)
                     except Exception as err:
                         # If something goes wrong with the workload that isn't caught,
                         # a traceback will likely be useful

--- a/lib/clusterbuster/pod_files/failure.py
+++ b/lib/clusterbuster/pod_files/failure.py
@@ -2,7 +2,7 @@
 
 import time
 
-from clusterbuster_pod_client import clusterbuster_pod_client
+from clusterbuster_pod_client import clusterbuster_pod_client, ClusterBusterPodClientException
 
 
 class failure_client(clusterbuster_pod_client):
@@ -22,7 +22,7 @@ class failure_client(clusterbuster_pod_client):
         time.sleep(self.__delaytime)
 
         self._timestamp(f'About to fail after {self.__delaytime} seconds!')
-        raise Exception(f'Failing as intended after {self.__delaytime} seconds')
+        raise ClusterBusterPodClientException(f'Failing as intended after {self.__delaytime} seconds')
 
 
 failure_client().run_workload()

--- a/lib/clusterbuster/pod_files/files.py
+++ b/lib/clusterbuster/pod_files/files.py
@@ -6,7 +6,7 @@ import subprocess
 import mmap
 import shutil
 
-from clusterbuster_pod_client import clusterbuster_pod_client
+from clusterbuster_pod_client import clusterbuster_pod_client, ClusterBusterPodClientException
 
 
 class files_client(clusterbuster_pod_client):
@@ -60,21 +60,21 @@ class files_client(clusterbuster_pod_client):
                     try:
                         fd = os.open(filename, self.flags | os.O_WRONLY | os.O_CREAT)
                     except Exception as exc:
-                        raise Exception(f"Create failed on {filename} (file {files_created}): {exc}") from None
+                        raise ClusterBusterPodClientException(f"Create failed on {filename} (file {files_created}): {exc}") from None
                     ops = ops + 1
                     files_created = files_created + 1
                     for block in range(self.block_count):
                         try:
                             answer = os.write(fd, buf)
                             if answer != self.blocksize:
-                                raise os.IOError(f"Incomplete write to {filename} (file {files_created}): {answer} bytes, expect {self.blocksize}")
+                                raise ClusterBusterPodClientException(f"Incomplete write to {filename} (file {files_created}): {answer} bytes, expect {self.blocksize}")
                             ops = ops + 1
                         except IOError as exc:
-                            raise Exception(f"Write failed to {filename} (file {files_created}): {exc}") from None
+                            raise ClusterBusterPodClientException(f"Write failed to {filename} (file {files_created}): {exc}") from None
                     try:
                         os.close(fd)
                     except IOError as exc:
-                        raise Exception(f"Unable to close {filename} (file {files_created}): {exc}") from None
+                        raise ClusterBusterPodClientException(f"Unable to close {filename} (file {files_created}): {exc}") from None
         return ops
 
     def readthem(self, pid: int, oktofail: bool = False):

--- a/lib/clusterbuster/pod_files/memory.py
+++ b/lib/clusterbuster/pod_files/memory.py
@@ -8,7 +8,7 @@ import math
 import os
 import numpy.random
 
-from clusterbuster_pod_client import clusterbuster_pod_client
+from clusterbuster_pod_client import clusterbuster_pod_client, ClusterBusterPodClientException
 
 
 class memory_client(clusterbuster_pod_client):
@@ -35,7 +35,7 @@ class memory_client(clusterbuster_pod_client):
             self.__run_in_subproc = bool(int(self._args[11]))
             self.__start_probability = None if self._args[12] == '' else float(self._args[12])
             if self.__start_probability is not None and (self.__start_probability < 0 or self.__start_probability > 1):
-                raise ValueError(f"Start probability must be between 0 and 1 ({self.__start_probability})")
+                raise ClusterBusterPodClientException(f"Start probability must be between 0 and 1 ({self.__start_probability})")
 #            if self.__runtime > 0:
 #                self.__iterations = int(self.__runtime)
             if not self.__stride or self.__stride <= 0:
@@ -164,7 +164,7 @@ class memory_client(clusterbuster_pod_client):
                     try:
                         cpid, status = os.waitpid(pid)
                         if status:
-                            raise Exception(f"Child failed, status {int(status / 256)}")
+                            raise ClusterBusterPodClientException(f"Child failed, status {int(status / 256)}")
                     except Exception:
                         pass
         else:

--- a/lib/clusterbuster/pod_files/sysbench.py
+++ b/lib/clusterbuster/pod_files/sysbench.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import time
 
-from clusterbuster_pod_client import clusterbuster_pod_client
+from clusterbuster_pod_client import clusterbuster_pod_client, ClusterBusterPodClientException
 
 
 class sysbench_client(clusterbuster_pod_client):
@@ -63,10 +63,8 @@ class sysbench_client(clusterbuster_pod_client):
                 multiplier = [1.0 for i in range(len(key))]
             elif isinstance(multiplier, int) or isinstance(multiplier, float):
                 multiplier = [multiplier for i in range(len(key))]
-            elif not isinstance(matchidx, list) or len(matchidx) < len(key):
-                raise Exception("Non-conformant multiplier")
             if not isinstance(matchidx, list) or len(matchidx) < len(key):
-                raise Exception("Non-conformant multiplier")
+                raise ClusterBusterPodClientException("Non-conformant multiplier")
             for i in range(len(key)):
                 self.simple_check1(m, op_answer, key[i], multiplier[i], matchidx[i], is_float, is_str, is_int)
         else:
@@ -119,7 +117,7 @@ class sysbench_client(clusterbuster_pod_client):
                 line = run.stdout.readline().decode('ascii')
             status = run.wait()
             if status:
-                raise Exception(f"Sysbench failed: {status}")
+                raise ClusterBusterPodClientException(f"Sysbench failed: {status}")
         op_answer['op_end'] = self._adjusted_time()
         data_end_time = self._adjusted_time()
         elapsed_time = data_end_time - data_start_time
@@ -208,7 +206,7 @@ class sysbench_client(clusterbuster_pod_client):
                         line = run.stdout.readline().decode('ascii')
                     status = run.wait()
                     if status:
-                        raise Exception(f"Sysbench failed: {status}")
+                        raise ClusterBusterPodClientException(f"Sysbench failed: {status}")
                 op_answer['op_end'] = self._adjusted_time()
                 op_answer['user_cpu_time'], op_answer['sys_cpu_time'] = self._cputimes(op_user, op_sys)
                 self._sync_to_controller(f'{test}+{mode}+finish')

--- a/lib/clusterbuster/reporting/analysis/ci/fio_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/ci/fio_analysis.py
@@ -23,4 +23,4 @@ class fio_analysis(CIAnalysis):
 
     def __init__(self, workload: str, data: dict, metadata: dict):
         super().__init__(workload, data, metadata,
-                         ['pods', 'ioengine', 'iodepth', 'fdatasync', 'direct', 'pattern', 'blocksize', 'runtime'])
+                         ['pods', 'ioengine', 'iodepth', 'numjobs', 'fdatasync', 'direct', 'pattern', 'blocksize', 'runtime'])

--- a/lib/clusterbuster/reporting/analysis/spreadsheet/fio_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/spreadsheet/fio_analysis.py
@@ -22,7 +22,7 @@ class fio_analysis(SpreadsheetAnalysis):
     """
 
     def __init__(self, workload: str, data: dict, metadata: dict):
-        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', '-By Fdatasync', 'By Direct', 'By Operation', 'By Blocksize']
+        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', 'By Numjobs', '-By Fdatasync', 'By Direct', 'By Operation', 'By Blocksize']
         variables = [
             {
              'var': 'throughput',

--- a/lib/clusterbuster/reporting/loader/fio_loader.py
+++ b/lib/clusterbuster/reporting/loader/fio_loader.py
@@ -31,13 +31,14 @@ class fio_loader(ClusterBusterLoadOneReportBase):
             fdatasync = job_metadata['fdatasync']
             direct = job_metadata['direct']
             ioengine = job_metadata['ioengine']
+            numjobs = job_metadata.get('numjobs', 1)
             if 'results' not in self._summary or job not in self._summary['results']:
                 print(f'Cannot load fio results for {self._metadata["job_name"]}/{job}', file=sys.stderr)
                 continue
             result = self._summary['results'][job]['job_results']
-            self._MakeHierarchy(self._data, ['fio', self._count, ioengine, iodepth, fdatasync,
+            self._MakeHierarchy(self._data, ['fio', self._count, ioengine, iodepth, numjobs, fdatasync,
                                              direct, pattern, blocksize, self._name, 'total'])
-            root = self._data['fio'][self._count][ioengine][iodepth][fdatasync][direct][pattern][blocksize][self._name]
+            root = self._data['fio'][self._count][ioengine][iodepth][numjobs][fdatasync][direct][pattern][blocksize][self._name]
             lat_counter = 0
             for op, data in result.items():
                 if 'data_rate' in result[op]:

--- a/lib/clusterbuster/reporting/reporter/fio_reporter.py
+++ b/lib/clusterbuster/reporting/reporter/fio_reporter.py
@@ -45,6 +45,7 @@ class fio_reporter(ClusterBusterReporter):
             pjob = f'job: {job}'
             if pjob not in dest:
                 dest[pjob] = {}
+            numjobs = self._jobs[job].get('numjobs', 1)
             for op in self._fio_operations:
                 if op not in source[job]['job_results']:
                     continue
@@ -56,7 +57,7 @@ class fio_reporter(ClusterBusterReporter):
                     dest1 = dest[pjob][pop]
                     ios = source1['total_ios']
                     nbytes = source1['io_kbytes'] * 1024
-                    runtime = source1['runtime'] / rows / 1000.0
+                    runtime = source1['runtime'] / numjobs / rows / 1000.0
                     dest1['io_bytes'] = self._prettyprint(nbytes, precision=3, suffix='B', integer=1)
                     dest1['total_ios'] = self._prettyprint(ios, base=1000, precision=3, integer=1)
                     dest1['runtime'] = self._prettyprint(runtime, base=1000, precision=3, suffix='sec')

--- a/lib/clusterbuster/workloads/classic.workload
+++ b/lib/clusterbuster/workloads/classic.workload
@@ -31,8 +31,16 @@ function classic_document() {
 EOF
 }
 
+function classic_supports_reporting() {
+    false
+}
+
 function classic_workload_reporting_class() {
     echo generic
+}
+
+function classic_calculate_logs_required() {
+    echo 0
 }
 
 register_workload classic clusterbuster

--- a/lib/clusterbuster/workloads/fio.workload
+++ b/lib/clusterbuster/workloads/fio.workload
@@ -22,6 +22,7 @@ declare -ag ___fio_options=()
 declare -ag ___fio_blocksizes=(4096)
 declare -ag ___fio_patterns=(read)
 declare -ag ___fio_iodepths=(1)
+declare -ag ___fio_numjobs=(1)
 declare -ag ___fio_directs=(0)
 declare -ag ___fio_fdatasyncs=(1)
 declare -ag ___fio_ioengines=(libaio)
@@ -46,7 +47,7 @@ function fio_arglist() {
     while [[ "$1" != '--' ]] ; do shift; done; shift
     mk_yaml_args "python3" "${mountdir}fio.py" "$@" \
 		 "$processes_per_pod" "$___fio_workdir" "$workload_run_time" "$user_configmap_mount_dir" \
-		 "${___fio_blocksizes[*]:-}" "${___fio_patterns[*]:-}" "${___fio_iodepths[*]:-}" \
+		 "${___fio_blocksizes[*]:-}" "${___fio_patterns[*]:-}" "${___fio_iodepths[*]:-}" "${___fio_numjobs[*]:-}" \
 		 "${___fio_fdatasyncs[*]:-}" "${___fio_directs[*]:-}" "${___fio_ioengines[*]:-}" \
 		 "$___fio_ramp_time" "$___fio_drop_cache" "${___fio_options[*]:-}"
 }
@@ -80,8 +81,11 @@ function fio_help_options() {
                         Comma-separated list of names of ioengines to use
                         (default ${___fio_ioengines[*]})
        --fio-iodepth=<n>
-                        Comma-separated list of names of I/O depths to use
+                        Comma-separated list of I/O depths to use
                         I/O depth (default ${___fio_iodepths[*]})
+       --fio-numjobs=<n>
+                        Comma-separated list of job counts depths to use
+                        I/O depth (default ${___fio_numjobs[*]})
        --fio-direct=<directs>
                         Comma-separated list of whether to use direct I/O
                         (default ${___fio_directs[*]}), values are 0 or 1.
@@ -113,6 +117,7 @@ function fio_process_options() {
     local fioblksize=
     local fiopattern=
     local fioiodepth=
+    local fionumjobs=
     local fiodirect=
     local fiofdatasync=
     local fioioengine=
@@ -125,6 +130,7 @@ function fio_process_options() {
 	    fiojobfile)		___fio_job_file=$optvalue		 ;;
 	    fioioengine*)	fioioengine=$optvalue			 ;;
 	    fioiodepth*)	fioiodepth=$optvalue			 ;;
+	    fionumjobs)		fionumjobs=$optvalue			 ;;
 	    fiodirect*)		fiodirect=$optvalue			 ;;
 	    fioramptime)	___fio_ramp_time=$optvalue		 ;;
 	    fiofdatasync*)	fiofdatasync=$optvalue			 ;;
@@ -150,6 +156,10 @@ function fio_process_options() {
     if [[ -n "${fioiodepth:-}" ]] ; then
 	# shellcheck disable=SC2086
 	readarray -t ___fio_iodepths <<< "$(parse_size ${fioiodepth//,/ })"
+    fi
+    if [[ -n "${fionumjobs:-}" ]] ; then
+	# shellcheck disable=SC2086
+	readarray -t ___fio_numjobs <<< "$(parse_size ${fionumjobs//,/ })"
     fi
     if [[ -n "${fiopattern:-}" ]] ; then
 	___fio_patterns=(${fiopattern//,/ })
@@ -179,6 +189,7 @@ function fio_generate_metadata() {
     local pattern
     local -i blocksize
     local -i iodepth
+    local -i numjobs
     local -i fdatasync
     local -i direct
     local ioengine
@@ -186,21 +197,24 @@ function fio_generate_metadata() {
     for blocksize in "${___fio_blocksizes[@]}" ; do
 	for pattern in "${___fio_patterns[@]}" ; do
 	    for iodepth in "${___fio_iodepths[@]}" ; do
-		for fdatasync in "${___fio_fdatasyncs[@]}" ; do
-		    for direct in "${___fio_directs[@]}" ; do
-			for ioengine in "${___fio_ioengines[@]}" ; do
-			    jobs+=("$(cat <<EOF
-$(printf '"%04d-%s-%d-%d-%d-%d-%s"' $((jobidx)) "$pattern" "$blocksize" "$iodepth" "$fdatasync" "$direct" "$ioengine"): {
+		for numjobs in "${___fio_numjobs[@]}" ; do
+		    for fdatasync in "${___fio_fdatasyncs[@]}" ; do
+			for direct in "${___fio_directs[@]}" ; do
+			    for ioengine in "${___fio_ioengines[@]}" ; do
+				jobs+=("$(cat <<EOF
+$(printf '"%04d-%s-%d-%d-%d-%d-%d-%s"' $((jobidx)) "$pattern" "$blocksize" "$iodepth" "$numjobs" "$fdatasync" "$direct" "$ioengine"): {
  "pattern": "$pattern",
  "blocksize": $blocksize,
  "iodepth": $iodepth,
+ "numjobs": $numjobs,
  "fdatasync": $fdatasync,
  "direct": $direct,
  "ioengine": "$ioengine"
 }
 EOF
 )")
-			    jobidx=$((jobidx+1))
+				jobidx=$((jobidx+1))
+			    done
 			done
 		    done
 		done
@@ -217,6 +231,7 @@ function fio_report_options() {
 "fio_job_file": "$(base64 -w 0 < "$___fio_processed_job_file")",
 "fio_ioengine": $(mk_str_list "${___fio_ioengines[@]}"),
 "fio_iodepth": $(mk_num_list "${___fio_iodepths[@]}"),
+"fio_numjobs": $(mk_num_list "${___fio_numjobs[@]}"),
 "fio_direct": $(mk_num_list "${___fio_directs[@]}"),
 "fio_fdatasync": $(mk_num_list "${___fio_fdatasyncs[@]}"),
 "fio_ioengines": $(mk_str_list "${___fio_ioengines[@]}"),

--- a/lib/clusterbuster/workloads/fio/generic.jobfile
+++ b/lib/clusterbuster/workloads/fio/generic.jobfile
@@ -17,6 +17,5 @@ invalidate = %{___fio_drop_cache}
 [job-tmp]
 filename =%{___fio_workdir}
 size =%{___fio_filesize}
-numjobs = 1
 
 #rate_iops=10

--- a/ocp4-upi-util
+++ b/ocp4-upi-util
@@ -63,6 +63,7 @@ declare -A install_disks=()
 declare -i processed_cmdline_vars=0
 declare -A known_macaddrs=()
 declare -i checked_config=0
+declare channel=
 declare -A needs_config_file=()
 platform=$(uname -i)
 # shellcheck disable=SC2155
@@ -78,15 +79,22 @@ declare -r command_help=$(expand <<'EOF'
     Commands:
       * install <version>        Install a baremetal cluster using UPI
       * do_install <version>     (deprecated) Same as install
-        install_cnv              Install sandboxed containers into cluster
-        install_kata             Install sandboxed containers into cluster
         bootstrap_destroy        Destroy any (virtual) bootstrap node
       * setup_dnsmasq            Set up dnsmasq/haproxy configuration
       * setup_infra              Set up an infra node
         migrate_infra            Migrate infra components to set up infra node
         describe_operator <op>   Describe the specified operator
         list_operators           List available operators
-        install_operator <op>    Install the specified operator
+        install_operator <options> <op>
+                                 Install the specified operator
+                                 Options:
+                                 -n           Do not actually install the
+                                              operator
+                                 -c channel   Use the specified channel
+        install_cnv              Install sandboxed containers into cluster
+                                 Same options as install_operator
+        install_kata             Install sandboxed containers into cluster
+                                 Same options as install_operator
      The following commands all use IPMI:
       * reset_all                Reset all nodes
       * reset_masters            Reset all master nodes
@@ -1255,13 +1263,17 @@ function __get_ns_version() {
 
 function __get_operator_channel() {
     local operator=$1
-    oc get packagemanifest -n openshift-marketplace "$operator" -ojsonpath='{.status.defaultChannel}'
+    if [[ -n "$channel" ]] ; then
+	echo "$channel"
+    else
+	oc get packagemanifest -n openshift-marketplace "$operator" -ojsonpath='{.status.defaultChannel}'
+    fi
 }
 
 function __get_operator_field() {
     local operator=$1
     local field=$2
-    local channel
+    local channel=${channel:+$channel}
     channel="${3:-$(__get_operator_channel "$operator")}"
     oc get packagemanifest -n openshift-marketplace "$operator" -ojson | jq -r '[foreach .status.channels[] as $channel ([[],[]];0; (if ($channel.name == "'"$channel"'") then $channel.'"$field"' else null end))] | flatten | map (select (. != null))[]'
 }
@@ -1383,7 +1395,7 @@ function __do_install_kata() {
 	echo '*** Kata already installed'
     fi
     echo '*** Installing Kata'
-    install_operator sandboxed-containers-operator
+    install_operator "$@" sandboxed-containers-operator
     # Wait for kataconfig to exist as a CRD.
     # Probably should have a timeout here.
     until oc get kataconfig -A >/dev/null 2>&1 ; do sleep 1; done
@@ -1463,7 +1475,7 @@ function __do_install_cnv() {
 	echo '*** CNV already installed'
     fi
     echo '*** Installing CNV'
-    install_operator kubevirt-hyperconverged
+    install_operator "$@" kubevirt-hyperconverged
     # Wait for kataconfig to exist as a CRD.
     # Probably should have a timeout here.
     until oc get hyperconverged -A >/dev/null 2>&1 ; do sleep 1; done
@@ -1775,9 +1787,11 @@ function setup_infra() {
 function install_operator() {
     local -i doit=1
     local OPTIND=0
-    while getopts "n" opt "$@" ; do
+    local OPTARG
+    while getopts "nc:" opt "$@" ; do
 	case "$opt" in
 	    n) doit=0 ;;
+	    c) channel="$OPTARG" ;;
 	    *) ;;
 	esac
     done
@@ -1785,9 +1799,9 @@ function install_operator() {
     local operator
     for operator in "$@" ; do
 	if ((doit)) ; then
-	    oc apply -f <(__generate_operator_yaml "$operator")
+	    oc apply -f <(__generate_operator_yaml ${channel:+-c "$channel"} "$operator")
 	else
-	    __generate_operator_yaml "$operator"
+	    __generate_operator_yaml ${channel:+-c "$channel"} "$operator"
 	fi
     done
 }

--- a/prom-extract
+++ b/prom-extract
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import print_function
+import sys
 
 
 def eprint(*args, **kwargs):
@@ -27,11 +28,37 @@ def efail(*args, **kwargs):
     sys.exit(1)
 
 
+failed_modules = []
+
 try:
-    import sys
     from prometheus_api_client import PrometheusConnect
-    import argparse
+except (KeyboardInterrupt, BrokenPipeError):
+    efail('')
+except ModuleNotFoundError:
+    failed_modules.append("prometheus_api_client")
+
+
+try:
     from jinja2 import Template
+except (KeyboardInterrupt, BrokenPipeError):
+    efail('')
+except ModuleNotFoundError:
+    failed_modules.append("jinja2")
+
+
+try:
+    import openshift_client
+except (KeyboardInterrupt, BrokenPipeError):
+    efail('')
+except ModuleNotFoundError:
+    failed_modules.append("openshift_client")
+
+if failed_modules:
+    efail("prom-extract failed: the following Python modules are missing:", failed_modules)
+
+
+try:
+    import argparse
     import selectors
     import time
     import os
@@ -41,7 +68,6 @@ try:
     import urllib3
     import uuid
     import yaml
-    import openshift_client
 except (KeyboardInterrupt, BrokenPipeError):
     efail('')
 except ModuleNotFoundError as exc:
@@ -122,7 +148,7 @@ def get_prometheus_timestamp():
         try:
             with openshift_client.project('openshift-monitoring'):
                 result = openshift_client.selector('pod/prometheus-k8s-0').object().execute(['date', '+%s.%N'],
-                                                                                     container_name='prometheus')
+                                                                                            container_name='prometheus')
                 return datetime.fromtimestamp(float(result.out()), timezone.utc)
         except (KeyboardInterrupt, BrokenPipeError):
             efail('')


### PR DESCRIPTION
 - Fix the error helper.
  The error helper is prone to an issue where the sync flag file
  is created and then removed between iterations in its loop,
  resulting in the fail helper never completing.  This did not
  fail in 4.17, but is failing erratically in 4.19 for unclear
  reasons, but the old logic did not look correct.
  Fix is two parts:
  1) Create a new sync done file that the log retriever
     creates, indicating that it is reading the data
     and the error helper can exit.
  2) If the done file or flag file exist, exit the sync pod loop
     with a specific message that the helper can look for and itself
     exit.
- Add numjobs for fio
- Fix requirement for prom-extract.
- Initialize options prior to describe_options being called.
- Fix the classic workload to not attempt to retrieve logs. This bug has been around for a while, but this workload is not frequently used.
- Timestamp the objects created information from clusterbuster.
- If prom-extract fails to start due to missing modules, list them
- Don't print python stack trace in known failures in clusterbuster.
- Container build: add 'make clean' target.
- ocp4-upi-util:
  - Add install_operator -n to just print what would be done without installing.
  - Add install_operator -c channel to permit specifying the channel to install