### PR TITLE
Deprecate ClusterBuster and related tools from RobertKrawitz/OpenShift4-tools

### DIFF
--- a/CI/run-perf-ci-suite
+++ b/CI/run-perf-ci-suite
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+cat <<EOF
+${0##/*} in RobertKrawitz/OpenShift4-tools has been deprecated and
+will be removed from that repo on or after October 1, 2025.  It is now
+found in redhat-performance/clusterbuster.  Please update your repo
+accordingly.
+EOF
+
 declare -i set_u_works=1
 if (( BASH_VERSINFO[0] >= 5 || (BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4) )) ; then
     set -u

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [Robert Krawitz's](mailto:rlk@redhat.com) tools for installing
 etc. OpenShift 4 clusters.
 
+***NOTE*** Clusterbuster and related tools have been migrated to a new
+repo, redhat-performance/clusterbuster, and are deprecated from this
+repo.  They will be removed from main on or after October 1, 2025.
+
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 
@@ -61,19 +65,15 @@ etc. OpenShift 4 clusters.
 
 ## Testing tools
 
+**NOTE** These tools are deprecated from this repo and will be removed
+on or after October 1, 2025.  The new location is
+redhat-performance/clusterbuster. Please update accordingly.
+
 - **clusterbuster** -- generate pods, namespaces, and secrets to stress
   test a cluster.  See [documentation](docs/clusterbuster.md)
 
 - **force-pull-clusterbuster-image** - force-pull the ClusterBuster
   images so that they are present on all nodes in a cluster.
-
-## Data reporting utilities
-
-- **monitor-cluster-resources** -- monitor CPU, memory, and pod
-  utilization per-node in real time.
-
-- **net-traffic** -- report information about network traffic similar
-  to iostat.
 
 - **prom-extract**: Capture selected Prometheus data for the duration
   of a run; report the results along with metadata and workload output
@@ -181,6 +181,14 @@ etc. OpenShift 4 clusters.
     report.  If not provided, one is generated and reported on
     stderr.  This is useful for e. g. indexing the report into a
     database.
+
+## Data reporting utilities
+
+- **monitor-cluster-resources** -- monitor CPU, memory, and pod
+  utilization per-node in real time.
+
+- **net-traffic** -- report information about network traffic similar
+  to iostat.
 
 ## General information tools
 

--- a/analyze-clusterbuster-report
+++ b/analyze-clusterbuster-report
@@ -21,6 +21,13 @@ from lib.clusterbuster.reporting.analysis.ClusterBusterAnalysis import ClusterBu
 from lib.clusterbuster.reporting.loader.ClusterBusterLoader import ClusterBusterLoader
 from lib.clusterbuster.reporting.reporting_exceptions import ClusterBusterReportingException
 
+print("""
+ClusterBuster and associated tools in RobertKrawitz/OpenShift4-tools have
+been deprecated and will be removed from that repo on or after
+October 1, 2025.  It is now found in redhat-performance/clusterbuster.
+Please update your repo accordingly.
+""", file=sys.stderr)
+
 if 'CB_LIBPATH' in os.environ:
     sys.path = [element for element in os.environ['CB_LIBPATH'].split(':')] + sys.path
 parser = argparse.ArgumentParser(description='Analyze ClusterBuster report')

--- a/clusterbuster
+++ b/clusterbuster
@@ -48,6 +48,12 @@ function clean_startup() {
 # It's fine for the running script to be removed, since the shell still
 # has its open file descriptor.
 if [[ $# = 0 || $1 != "--DoIt=$0" ]] ; then
+    cat <<EOF
+${0##/*} in RobertKrawitz/OpenShift4-tools has been deprecated and
+will be removed from that repo on or after October 1, 2025.  It is now
+found in redhat-performance/clusterbuster.  Please update your repo
+accordingly.
+EOF
     tmpsc=$(mktemp -t "${__topsc__}".XXXXXXXXXX)
     [[ -z $tmpsc || ! -f $tmpsc || -L $tmpsc ]] && fatal "Can't create temporary script file"
     trap clean_startup EXIT SIGHUP SIGINT SIGQUIT SIGTERM

--- a/clusterbuster-report
+++ b/clusterbuster-report
@@ -20,6 +20,12 @@ from lib.clusterbuster.reporting.reporter.ClusterBusterReporter import ClusterBu
 import traceback
 import os
 
+print("""
+ClusterBuster and associated tools in RobertKrawitz/OpenShift4-tools have
+been deprecated and will be removed from that repo on or after
+October 1, 2025.  It is now found in redhat-performance/clusterbuster.
+Please update your repo accordingly.
+""", file=sys.stderr)
 
 if 'CB_LIBPATH' in os.environ:
     sys.path = [element for element in os.environ['CB_LIBPATH'].split(':')] + sys.path

--- a/docs/clusterbuster.md
+++ b/docs/clusterbuster.md
@@ -1,5 +1,10 @@
 # ClusterBuster
 
+**ClusterBuster is deprecated from this repo
+(RobertKrawitz/OpenShift4-tools) and going forward is found in
+redhat-performance/clusterbuster.  It will be removed from this repo
+on or after October 1, 2025.**
+
 Clusterbuster is (yet another) tool for running workloads on OpenShift
 clusters.  Its purpose is to simplify running workloads from the
 command line and does not require external resources such as

--- a/force-pull-clusterbuster-image
+++ b/force-pull-clusterbuster-image
@@ -17,6 +17,13 @@ declare OC=${OC:-${KUBECTL:-}}
 OC=${OC:-$(type -p oc)}
 OC=${OC:-$(type -p kubectl)}	# kubectl might not work, though...
 
+cat <<EOF
+${0##/*} in RobertKrawitz/OpenShift4-tools has been deprecated and
+will be removed from that repo on or after October 1, 2025.  It is now
+found in redhat-performance/clusterbuster.  Please update your repo
+accordingly.
+EOF
+
 declare image_tag=latest
 
 while getopts 't:' opt ; do

--- a/prom-extract
+++ b/prom-extract
@@ -28,6 +28,13 @@ def efail(*args, **kwargs):
     sys.exit(1)
 
 
+eprint("""
+ClusterBuster and associated tools in RobertKrawitz/OpenShift4-tools have
+been deprecated and will be removed from that repo on or after
+October 1, 2025.  It is now found in redhat-performance/clusterbuster.
+Please update your repo accordingly.
+""")
+
 failed_modules = []
 
 try:


### PR DESCRIPTION
Going forward, ClusterBuster lives in redhat-performance/clusterbuster.  Clusterbuster will be removed from this repo on or after October 1, 2025.